### PR TITLE
Add support for TEXCOORD_2 and TEXCOORD_3

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -52,6 +52,8 @@ typedef enum cgltf_attribute_type
 	cgltf_attribute_type_tangent,
 	cgltf_attribute_type_texcoord_0,
 	cgltf_attribute_type_texcoord_1,
+	cgltf_attribute_type_texcoord_2,
+	cgltf_attribute_type_texcoord_3,
 	cgltf_attribute_type_color_0,
 	cgltf_attribute_type_joints_0,
 	cgltf_attribute_type_weights_0,
@@ -640,6 +642,14 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "TEXCOORD_1") == 0)
 				{
 					out_prim->attributes[iattr].name = cgltf_attribute_type_texcoord_1;
+				}
+				else if (cgltf_json_strcmp(tokens+i, json_chunk, "TEXCOORD_2") == 0)
+				{
+					out_prim->attributes[iattr].name = cgltf_attribute_type_texcoord_2;
+				}
+				else if (cgltf_json_strcmp(tokens+i, json_chunk, "TEXCOORD_3") == 0)
+				{
+					out_prim->attributes[iattr].name = cgltf_attribute_type_texcoord_3;
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "COLOR_0") == 0)
 				{


### PR DESCRIPTION
At some point we should keep the attribute name around for unknown
attributes, but this tactically lets us use up to 4 UV sets.