### PR TITLE
Implement camera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ cgltf supports this:
 - scenes and nodes
 - skins
 - animations
+- cameras
 
 cgltf does **not** yet support this:
-- cameras
 - morph targets
 - any extensions (like Draco, for example)
 


### PR DESCRIPTION
We now parse perspective and orthographic camera definitions from GLTF
file as well as node->camera bindings.

Camera is structured as an enum type + union of two possible struct
values, with straightforward future extensions if GLTF adds more camera
types.