### PR TITLE
Parse accessor min/max limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Note that cgltf does not load the contents of extra files such as buffers or ima
 
 ## Support
 
-cgltf supports most core glTF 2.0 features:
+cgltf supports core glTF 2.0:
 - glb (binary files) and gltf (JSON files)
 - meshes (including accessors, buffer views, buffers)
 - materials (including textures, samplers, images)
@@ -48,13 +48,12 @@ cgltf supports most core glTF 2.0 features:
 - skins
 - animations
 - cameras
+- morph targets
 
 cgltf also supports some glTF extensions:
 - KHR_materials_pbrSpecularGlossiness
 
-cgltf does **not** yet support this:
-- morph targets
-- any unlisted extensions (like Draco, for example)
+cgltf does **not** yet support unlisted extensions or `extra` data.
 
 ## Building
 The easiest approach is to integrate the `cgltf.h` header file into your project. If you are unfamiliar with single-file C libraries (also known as stb-style libraries), this is how it goes:

--- a/cgltf.h
+++ b/cgltf.h
@@ -155,6 +155,10 @@ typedef struct cgltf_accessor
 	cgltf_size count;
 	cgltf_size stride;
 	cgltf_buffer_view* buffer_view;
+	cgltf_bool has_min;
+	cgltf_float min[16];
+	cgltf_bool has_max;
+	cgltf_float max[16];
 	cgltf_bool is_sparse;
 	cgltf_accessor_sparse sparse;
 } cgltf_accessor;
@@ -1281,6 +1285,30 @@ static int cgltf_parse_json_accessor(jsmntok_t const* tokens, int i, const uint8
 				out_accessor->type = cgltf_type_mat4;
 			}
 			++i;
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "min") == 0)
+		{
+			++i;
+			out_accessor->has_min = 1;
+			// note: we can't parse the precise number of elements since type may not have been computed yet
+			int min_size = tokens[i].size > 16 ? 16 : tokens[i].size;
+			i = cgltf_parse_json_float_array(tokens, i, json_chunk, out_accessor->min, min_size);
+			if (i < 0)
+			{
+				return i;
+			}
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "max") == 0)
+		{
+			++i;
+			out_accessor->has_max = 1;
+			// note: we can't parse the precise number of elements since type may not have been computed yet
+			int max_size = tokens[i].size > 16 ? 16 : tokens[i].size;
+			i = cgltf_parse_json_float_array(tokens, i, json_chunk, out_accessor->max, max_size);
+			if (i < 0)
+			{
+				return i;
+			}
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "sparse") == 0)
 		{


### PR DESCRIPTION
Since accessors can refer to values up to 16 scalars, the maximum size
of min/max arrays is 16.

We do not always know the size of the arrays because "type" is in the
same object and may happen after the arrays, so we just parse the entire
array - up to 16 elements to not cause heap overflow.
