### PR TITLE
Make sure cgltf deallocates all memory and handles all memory allocation failures

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -3240,6 +3240,11 @@ cgltf_result cgltf_parse_json(cgltf_options* options, const uint8_t* json_chunk,
 
 	jsmntok_t* tokens = (jsmntok_t*)options->memory_alloc(options->memory_user_data, sizeof(jsmntok_t) * options->json_token_count);
 
+	if (!tokens)
+	{
+		return cgltf_result_out_of_memory;
+	}
+
 	jsmn_init(&parser);
 
 	int token_count = jsmn_parse(&parser, (const char*)json_chunk, size, tokens, options->json_token_count);
@@ -3251,6 +3256,13 @@ cgltf_result cgltf_parse_json(cgltf_options* options, const uint8_t* json_chunk,
 	}
 
 	cgltf_data* data = (cgltf_data*)options->memory_alloc(options->memory_user_data, sizeof(cgltf_data));
+
+	if (!data)
+	{
+		options->memory_free(options->memory_user_data, tokens);
+		return cgltf_result_out_of_memory;
+	}
+
 	memset(data, 0, sizeof(cgltf_data));
 	data->memory_free = options->memory_free;
 	data->memory_user_data = options->memory_user_data;


### PR DESCRIPTION
This change reworks string and array parsing to avoid memory leaks on malformed documents.

Previously, if a JSON element specifying string/array data occurred in the document twice, the second occurrence would completely erase the previously parsed data, causing a memory leak.

With this change, we rely on new helpers parse_json_string and parse_json_array to handle this case by returning a parse error. Additionally, we use the same helpers to return a memory error (the need to differentiate between these is why the functions return int), which is then propagated to the user.

Additionally, this change fixes a couple of cases where memory_alloc failures weren't handled. We should now be completely leak-proof and handle all memory allocation failures.