### PR TITLE
Test cgltf_parse_file and cgltf_load_buffers in CI

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -872,13 +872,24 @@ cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, 
 		{
 			return cgltf_result_invalid_json;
 		}
-		else if (strncmp(uri, "data:application/octet-stream;base64,", 37) == 0)
+		else if (strncmp(uri, "data:", 5) == 0)
 		{
-			cgltf_result res = cgltf_load_buffer_base64(options, data->buffers[i].size, uri + 37, &data->buffers[i].data);
+			const char* comma = strchr(uri, ',');
 
-			if (res != cgltf_result_success)
+			cgltf_result res = cgltf_result_unknown_format;
+
+			if (comma && comma - uri >= 7 && strncmp(comma - 7, ";base64", 7) == 0)
 			{
-				return res;
+				cgltf_result res = cgltf_load_buffer_base64(options, data->buffers[i].size, comma + 1, &data->buffers[i].data);
+
+				if (res != cgltf_result_success)
+				{
+					return res;
+				}
+			}
+			else
+			{
+				return cgltf_result_unknown_format;
 			}
 		}
 		else if (strstr(uri, "://") == NULL)

--- a/cgltf.h
+++ b/cgltf.h
@@ -876,8 +876,6 @@ cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, 
 		{
 			const char* comma = strchr(uri, ',');
 
-			cgltf_result res = cgltf_result_unknown_format;
-
 			if (comma && comma - uri >= 7 && strncmp(comma - 7, ";base64", 7) == 0)
 			{
 				cgltf_result res = cgltf_load_buffer_base64(options, data->buffers[i].size, comma + 1, &data->buffers[i].data);

--- a/cgltf.h
+++ b/cgltf.h
@@ -854,7 +854,7 @@ cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, 
 		return cgltf_result_invalid_options;
 	}
 
-	if (data->buffers_count && data->buffers[0].data == NULL && data->bin)
+	if (data->buffers_count && data->buffers[0].data == NULL && data->buffers[0].uri == NULL && data->bin)
 	{
 		data->buffers[0].data = (void*)data->bin;
 	}

--- a/test/main.c
+++ b/test/main.c
@@ -13,33 +13,20 @@ int main(int argc, char** argv)
 		return -1;
 	}
 
-	FILE* f = fopen(argv[1], "rb");
-	if (!f)
-	{
-		return -2;
-	}
-
-	fseek(f, 0, SEEK_END);
-	long size = ftell(f);
-	fseek(f, 0, SEEK_SET);
-
-	void* buf = malloc(size);
-	fread(buf, size, 1, f);
-
-	fclose(f);
-
 	cgltf_options options = {0};
 	cgltf_data* data = NULL;
-	cgltf_result result = cgltf_parse(&options, buf, size, &data);
+	cgltf_result result = cgltf_parse_file(&options, argv[1], &data);
+
+	if (result == cgltf_result_success)
+		result = cgltf_load_buffers(&options, data, argv[1]);
 
 	printf("Result: %d\n", result);
+
 	if (result == cgltf_result_success)
 	{
 		printf("Type: %u\n", data->file_type);
 		printf("Meshes: %lu\n", data->meshes_count);
 	}
-
-	free(buf);
 
 	cgltf_free(data);
 


### PR DESCRIPTION
With this CI tests will run almost all of the code on glTF sample models
- this will validate that the code that loads external buffers and
parses Base64 data URIs is correct.

One of the sample models used a data URI with application/glb-buffer mime type, so this change makes Base64 decoding more generic.

Also while I'm here fix the buffer assignment for GLB-stored buffers (contributes to #14).