### PR TITLE
Fix GLB buffer handling when GLB buffer is too short

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -859,6 +859,11 @@ cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, 
 
 	if (data->buffers_count && data->buffers[0].data == NULL && data->buffers[0].uri == NULL && data->bin)
 	{
+		if (data->bin_size < data->buffers[0].size)
+		{
+			return cgltf_result_data_too_short;
+		}
+
 		data->buffers[0].data = (void*)data->bin;
 	}
 
@@ -873,9 +878,10 @@ cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, 
 
 		if (uri == NULL)
 		{
-			return cgltf_result_invalid_json;
+			continue;
 		}
-		else if (strncmp(uri, "data:", 5) == 0)
+
+		if (strncmp(uri, "data:", 5) == 0)
 		{
 			const char* comma = strchr(uri, ',');
 


### PR DESCRIPTION
When first buffer is loaded from the GLB binary chunk, if the chunk is
too small we'd be returning a data pointer to the user while supplying a
buffer that's too short to access safely, so this has to be an error.

Additionally fix handling of buffers with no URI - URI is optional as
per spec, and presumably buffers without a URI may have their contents
supplied via extensions. It seems better to keep the buffers like that
as is, that way the application can load these manually separately.