### PR TITLE
Add optional validation support

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -961,6 +961,36 @@ cgltf_result cgltf_validate(cgltf_data* data)
 		}
 	}
 
+	for (cgltf_size i = 0; i < data->meshes_count; ++i)
+	{
+		for (cgltf_size j = 0; j < data->meshes[i].primitives_count; ++j)
+		{
+			if (data->meshes[i].primitives[j].attributes_count)
+			{
+				cgltf_accessor* first = data->meshes[i].primitives[j].attributes[0].data;
+
+				for (cgltf_size k = 0; k < data->meshes[i].primitives[j].attributes_count; ++k)
+				{
+					if (data->meshes[i].primitives[j].attributes[k].data->count != first->count)
+					{
+						return cgltf_result_invalid_gltf;
+					}
+				}
+
+				for (cgltf_size k = 0; k < data->meshes[i].primitives[j].targets_count; ++k)
+				{
+					for (cgltf_size m = 0; m < data->meshes[i].primitives[j].targets[k].attributes_count; ++m)
+					{
+						if (data->meshes[i].primitives[j].targets[k].attributes[m].data->count != first->count)
+						{
+							return cgltf_result_invalid_gltf;
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return cgltf_result_success;
 }
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -963,8 +963,21 @@ cgltf_result cgltf_validate(cgltf_data* data)
 
 	for (cgltf_size i = 0; i < data->meshes_count; ++i)
 	{
+		if (data->meshes[i].weights)
+		{
+			if (data->meshes[i].primitives_count && data->meshes[i].primitives[0].targets_count != data->meshes[i].weights_count)
+			{
+				return cgltf_result_invalid_gltf;
+			}
+		}
+
 		for (cgltf_size j = 0; j < data->meshes[i].primitives_count; ++j)
 		{
+			if (data->meshes[i].primitives[j].targets_count != data->meshes[i].primitives[0].targets_count)
+			{
+				return cgltf_result_invalid_gltf;
+			}
+
 			if (data->meshes[i].primitives[j].attributes_count)
 			{
 				cgltf_accessor* first = data->meshes[i].primitives[j].attributes[0].data;
@@ -987,6 +1000,17 @@ cgltf_result cgltf_validate(cgltf_data* data)
 						}
 					}
 				}
+			}
+		}
+	}
+
+	for (cgltf_size i = 0; i < data->nodes_count; ++i)
+	{
+		if (data->nodes[i].weights && data->nodes[i].mesh)
+		{
+			if (data->nodes[i].mesh->primitives_count && data->nodes[i].mesh->primitives[0].targets_count != data->nodes[i].weights_count)
+			{
+				return cgltf_result_invalid_gltf;
 			}
 		}
 	}

--- a/fuzz/main.c
+++ b/fuzz/main.c
@@ -6,6 +6,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	cgltf_options options = {0};
 	cgltf_data* data = NULL;
 	cgltf_result res = cgltf_parse(&options, Data, Size, &data);
-	if (res == cgltf_result_success) cgltf_free(data);
+	if (res == cgltf_result_success)
+	{
+		cgltf_validate(data);
+		cgltf_free(data);
+	}
 	return 0;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -20,6 +20,9 @@ int main(int argc, char** argv)
 	if (result == cgltf_result_success)
 		result = cgltf_load_buffers(&options, data, argv[1]);
 
+	if (result == cgltf_result_success)
+		result = cgltf_validate(data);
+
 	printf("Result: %d\n", result);
 
 	if (result == cgltf_result_success)


### PR DESCRIPTION
This series of changes introduces cgltf_validate that performs the most critical validation checks (that are most likely to cause the application to misbehave when using parsed data), most of these are validating different sizes of different arrays against each other.

None of these checks require buffer access; if we introduce them later, we might need to add validation flags to the options.

Contributes to #14. (I feel like this set of validation checks is sufficient to address that with the exception of index data validation that I will submit separately)