### PR TITLE
Add data conversion functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ Everyone is welcome to contribute to the library. If you find any problems, you 
 ## Dependencies
 None.
 
-C headers being used:
+C headers being used by implementation:
 ```
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <limits.h>
 ```
 
 Note, this library has a copy of the [JSMN JSON parser](https://github.com/zserge/jsmn) embedded in its source.

--- a/README.md
+++ b/README.md
@@ -87,4 +87,11 @@ Note, this library has a copy of the [JSMN JSON parser](https://github.com/zserg
 ## Testing
 There is a Python script in the `test/` folder that retrieves the glTF 2.0 sample files from the glTF-Sample-Models repository (https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0) and runs the library against all gltf and glb files.
 
+Here's one way to build and run the test:
+
+    cd test ; mkdir build ; cd build ; cmake .. -DCMAKE_BUILD_TYPE=Debug
+    make -j
+    cd ..
+    ./test_all.py
+
 There is also a llvm-fuzz test in `fuzz/`. See http://llvm.org/docs/LibFuzzer.html for more information.

--- a/cgltf.h
+++ b/cgltf.h
@@ -1495,12 +1495,14 @@ cgltf_bool cgltf_accessor_read_float(const cgltf_accessor* accessor, cgltf_size 
 		cgltf_size index_stride = cgltf_component_size(sparse->indices_component_type);
 		const uint8_t* index_element = (const uint8_t*) sparse->indices_buffer_view->buffer->data;
 		index_element += index_offset + index_stride * index;
-		index = cgltf_component_read_index(index_element, sparse->indices_component_type);
-
-		cgltf_size offset = sparse->values_byte_offset + sparse->values_buffer_view->offset;
-		const uint8_t* element = (const uint8_t*) sparse->values_buffer_view->buffer->data;
-		element += offset + accessor->stride * index;
-		return cgltf_element_read_float(element, accessor->type, accessor->component_type, accessor->normalized, out, element_size);
+		size_t overlay_index = cgltf_component_read_index(index_element, sparse->indices_component_type);
+		if (overlay_index == index)
+		{
+			cgltf_size offset = sparse->values_byte_offset + sparse->values_buffer_view->offset;
+			const uint8_t* element = (const uint8_t*) sparse->values_buffer_view->buffer->data;
+			element += offset + accessor->stride * index;
+			return cgltf_element_read_float(element, accessor->type, accessor->component_type, accessor->normalized, out, element_size);
+		}
 	}
 
 	if (accessor->buffer_view)
@@ -1523,12 +1525,14 @@ cgltf_size cgltf_accessor_read_index(const cgltf_accessor* accessor, cgltf_size 
 		cgltf_size index_stride = cgltf_component_size(sparse->indices_component_type);
 		const uint8_t* index_element = (const uint8_t*) sparse->indices_buffer_view->buffer->data;
 		index_element += index_offset + index_stride * index;
-		index = cgltf_component_read_index(index_element, sparse->indices_component_type);
-
-		cgltf_size offset = sparse->values_byte_offset + sparse->values_buffer_view->offset;
-		const uint8_t* element = (const uint8_t*) sparse->values_buffer_view->buffer->data;
-		element += offset + accessor->stride * index;
-		return cgltf_component_read_index(element, accessor->component_type);
+		size_t overlay_index = cgltf_component_read_index(index_element, sparse->indices_component_type);
+		if (overlay_index == index)
+		{
+			cgltf_size offset = sparse->values_byte_offset + sparse->values_buffer_view->offset;
+			const uint8_t* element = (const uint8_t*) sparse->values_buffer_view->buffer->data;
+			element += offset + accessor->stride * index;
+			return cgltf_component_read_index(element, accessor->component_type);
+		}
 	}
 
 	if (accessor->buffer_view)
@@ -1539,7 +1543,7 @@ cgltf_size cgltf_accessor_read_index(const cgltf_accessor* accessor, cgltf_size 
 		return cgltf_component_read_index(element, accessor->component_type);
 	}
 
-	return (cgltf_size)(-1);
+	return 0;
 }
 
 #define CGLTF_ERROR_JSON -1

--- a/cgltf.h
+++ b/cgltf.h
@@ -44,6 +44,20 @@
  *
  * `cgltf_result cgltf_validate(cgltf_data*)` can be used to do additional
  * checks to make sure the parsed glTF data is valid.
+ *
+ * `cgltf_node_transform_local` converts the translation / rotation / scale properties of a node
+ * into a mat4.
+ *
+ * `cgltf_node_transform_world` calls `cgltf_node_transform_local` on every ancestor in order
+ * to compute the root-to-node transformation.
+ *
+ * `cgltf_accessor_read_float` reads a certain element from an accessor and converts it to
+ * floating point, assuming that `cgltf_load_buffers` has already been called. The passed-in element
+ * size is the number of floats in the output buffer, which should be in the range [1, 16]. Returns
+ * false if the passed-in element_size is too small.
+ *
+ * `cgltf_accessor_read_index` is similar to its floating-point counterpart, but it returns size_t
+ * and only works with single-component data types.
  */
 #ifndef CGLTF_H_INCLUDED__
 #define CGLTF_H_INCLUDED__
@@ -505,12 +519,7 @@ void cgltf_free(cgltf_data* data);
 void cgltf_node_transform_local(const cgltf_node* node, cgltf_float* out_matrix);
 void cgltf_node_transform_world(const cgltf_node* node, cgltf_float* out_matrix);
 
-// Reads the element at the given index and converts it to floating point. The passed-in element
-// size is the number of floats in the output buffer, which should be in the range [1, 16].
-// Returns false if the passed-in element_size is too small.
 cgltf_bool cgltf_accessor_read_float(const cgltf_accessor* accessor, cgltf_size index, cgltf_float* out, cgltf_size element_size);
-
-// Reads a single element from a scalar-typed accessor and converts it to size_t.
 cgltf_size cgltf_accessor_read_index(const cgltf_accessor* accessor, cgltf_size index);
 
 #ifdef __cplusplus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,9 +4,10 @@ include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 
 set( EXE_NAME cgltf_test )
 add_executable( ${EXE_NAME} main.c )
-set_property(TARGET ${EXE_NAME} PROPERTY C_STANDARD 99)
+set_property( TARGET ${EXE_NAME} PROPERTY C_STANDARD 99 )
 install( TARGETS ${EXE_NAME} RUNTIME DESTINATION bin )
 
 set( EXE_NAME test_conversion )
 add_executable( ${EXE_NAME} test_conversion.cpp )
+set_property( TARGET ${EXE_NAME} PROPERTY CXX_STANDARD 11 )
 install( TARGETS ${EXE_NAME} RUNTIME DESTINATION bin )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,14 +2,11 @@ cmake_minimum_required( VERSION 2.8 )
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 
-set( MAIN_SOURCES main.c )
+set( EXE_NAME cgltf_test )
+add_executable( ${EXE_NAME} main.c )
+set_property(TARGET ${EXE_NAME} PROPERTY C_STANDARD 99)
+install( TARGETS ${EXE_NAME} RUNTIME DESTINATION bin )
 
-set( MAIN_EXE_NAME cgltf_test )
-add_executable( ${MAIN_EXE_NAME} ${MAIN_SOURCES} )
-set_property(TARGET ${MAIN_EXE_NAME} PROPERTY C_STANDARD 99)
-
-target_link_libraries( ${MAIN_EXE_NAME} )
-
-install( TARGETS ${MAIN_EXE_NAME}
-	RUNTIME DESTINATION bin )
-
+set( EXE_NAME test_conversion )
+add_executable( ${EXE_NAME} test_conversion.cpp )
+install( TARGETS ${EXE_NAME} RUNTIME DESTINATION bin )

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -6,7 +6,7 @@ from sys import platform
 num_tested = 0
 num_errors = 0
 
-def collect_files(path, type):
+def collect_files(path, type, exe):
     global num_tested
     global num_errors
     for the_file in os.listdir(path):
@@ -17,16 +17,16 @@ def collect_files(path, type):
                 print("### Testing: " + file_path)
                 result = 0
                 if platform == "win32":
-                    result = os.system("build\\Debug\\cgltf_test \"" + file_path + "\"")
+                    result = os.system("build\\Debug\\{0} \"{1}\"".format(exe, file_path))
                 else:
-                    result = os.system("build/cgltf_test \"" + file_path + "\"")
+                    result = os.system("build/{0} \"{1}\"".format(exe, file_path))
                 print("### Result: " + str(result) + "\n")
                 if result != 0:
                     num_errors = num_errors + 1
                     print("Error.")
                     sys.exit(1)
         elif os.path.isdir(file_path):
-            collect_files(file_path, type)
+            collect_files(file_path, type, exe)
 
 if __name__ == "__main__":
     if not os.path.exists("build/"):
@@ -45,8 +45,10 @@ if __name__ == "__main__":
         f.close();
         os.system("git pull --depth=1 origin master")
         os.chdir("..")
-    collect_files("glTF-Sample-Models/2.0/", ".glb")
-    collect_files("glTF-Sample-Models/2.0/", ".gltf")
+    collect_files("glTF-Sample-Models/2.0/", ".glb", "cgltf_test")
+    collect_files("glTF-Sample-Models/2.0/", ".gltf", "cgltf_test")
+    collect_files("glTF-Sample-Models/2.0/", ".glb", "test_conversion")
+    collect_files("glTF-Sample-Models/2.0/", ".gltf", "test_conversion")
     print("Tested files: " + str(num_tested))
     print("Errors: " + str(num_errors))
 

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -1,0 +1,61 @@
+#define CGLTF_IMPLEMENTATION
+#include "../cgltf.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+static bool is_near(cgltf_float a, cgltf_float b)
+{
+	return std::abs(a - b) < 10 * std::numeric_limits<cgltf_float>::min();
+}
+
+int main(int argc, char** argv)
+{
+	if (argc < 2)
+	{
+		printf("err\n");
+		return -1;
+	}
+
+	cgltf_options options = {};
+	cgltf_data* data = NULL;
+	cgltf_result result = cgltf_parse_file(&options, argv[1], &data);
+
+	if (result == cgltf_result_success)
+		result = cgltf_load_buffers(&options, data, argv[1]);
+
+	if (result != cgltf_result_success || strstr(argv[1], "Draco"))
+		return result;
+
+	const cgltf_accessor* blobs = data->accessors;
+	cgltf_float element[16];
+	for (cgltf_size blob_index = 0; blob_index < data->accessors_count; ++blob_index)
+	{
+		const cgltf_accessor* blob = data->accessors + blob_index;
+		if (blob->has_max && blob->has_min)
+		{
+			cgltf_float min0 = std::numeric_limits<float>::max();
+			cgltf_float max0 = std::numeric_limits<float>::lowest();
+			for (cgltf_size index = 0; index < blob->count; index++)
+			{
+				cgltf_accessor_read_float(blob, index, element);
+				min0 = std::min(min0, element[0]);
+				max0 = std::max(max0, element[0]);
+			}
+			if (!is_near(min0, blob->min[0]) || !is_near(max0, blob->max[0]))
+			{
+				printf("Computed [%f, %f] but expected [%f, %f]\n", min0, max0, blob->min[0], blob->max[0]);
+				if (!blob->is_sparse)
+				{
+					return -1;
+				}
+			}
+		}
+	}
+
+	cgltf_free(data);
+
+	return result;
+}

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -34,6 +34,10 @@ int main(int argc, char** argv)
 	for (cgltf_size blob_index = 0; blob_index < data->accessors_count; ++blob_index)
 	{
 		const cgltf_accessor* blob = data->accessors + blob_index;
+		if (blob->is_sparse)
+		{
+			continue;
+		}
 		if (blob->has_max && blob->has_min)
 		{
 			cgltf_float min0 = std::numeric_limits<float>::max();

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -47,10 +47,7 @@ int main(int argc, char** argv)
 			if (!is_near(min0, blob->min[0]) || !is_near(max0, blob->max[0]))
 			{
 				printf("Computed [%f, %f] but expected [%f, %f]\n", min0, max0, blob->min[0], blob->max[0]);
-				if (!blob->is_sparse)
-				{
-					return -1;
-				}
+				return -1;
 			}
 		}
 	}

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
 			cgltf_float max0 = std::numeric_limits<float>::lowest();
 			for (cgltf_size index = 0; index < blob->count; index++)
 			{
-				cgltf_accessor_read_float(blob, index, element);
+				cgltf_accessor_read_float(blob, index, element, 16);
 				min0 = std::min(min0, element[0]);
 				max0 = std::max(max0, element[0]);
 			}


### PR DESCRIPTION
Fixes #46.
 
For the integer-based reading function, note that we return cgltf_size values instead of cgltf_int values.  For the rare cases where clients need to read negative values, they should use the float-based reader instead.

The reason we use size_t is that it's what we need internally for sparse support. Most clients will be reading indices anyway when using the integer-based reader function.