### PR TITLE
Fix variable shadowing

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1801,9 +1801,9 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 				return i;
 			}
 
-			for (cgltf_size j = 0; j < out_prim->targets_count; ++j)
+			for (cgltf_size k = 0; k < out_prim->targets_count; ++k)
 			{
-				i = cgltf_parse_json_attribute_list(options, tokens, i, json_chunk, &out_prim->targets[j].attributes, &out_prim->targets[j].attributes_count);
+				i = cgltf_parse_json_attribute_list(options, tokens, i, json_chunk, &out_prim->targets[k].attributes, &out_prim->targets[k].attributes_count);
 				if (i < 0)
 				{
 					return i;


### PR DESCRIPTION
Fixes this warning:

cgltf.h(1804): warning C4456: declaration of 'j' hides previous local declaration
cgltf.h(1768): note: see declaration of 'j'