### PR TITLE
Add missing includes to cgltf_write.h

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -56,6 +56,9 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #ifdef CGLTF_WRITE_IMPLEMENTATION
 
 #include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM   (1 << 0)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_UNLIT     (1 << 1)


### PR DESCRIPTION
It doesn't look like cgltf_write needs the CGLTF_IMPLEMENTATION to function, and with these headers cgltf_write compiles standalone