### PR TITLE
Convert decimal commas to decimal points when writing floats

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -185,10 +185,13 @@ static void cgltf_write_floatprop(cgltf_write_context* context, const char* labe
 		CGLTF_SPRINTF("%g", val);
 		context->needs_comma = 1;
 
-		char *decimal_comma = strchr(context->cursor - context->tmp, ',');
-		if (decimal_comma)
+		if (context->cursor)
 		{
-			*decimal_comma = '.';
+			char *decimal_comma = strchr(context->cursor - context->tmp, ',');
+			if (decimal_comma)
+			{
+				*decimal_comma = '.';
+			}
 		}
 	}
 }

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -181,8 +181,15 @@ static void cgltf_write_floatprop(cgltf_write_context* context, const char* labe
 	if (val != def)
 	{
 		cgltf_write_indent(context);
-		CGLTF_SPRINTF("\"%s\": %g", label, val);
+		CGLTF_SPRINTF("\"%s\": ", label);
+		CGLTF_SPRINTF("%g", val);
 		context->needs_comma = 1;
+
+		char *decimal_comma = strchr(context->cursor - context->tmp, ',');
+		if (decimal_comma)
+		{
+			*decimal_comma = '.';
+		}
 	}
 }
 


### PR DESCRIPTION
Some locales use , instead of . as a decimal separator which causes cgltf_write to generate invalid JSON

Locales are a pain to deal with and pulling in a float-to-string library adds quite a lot of code, so this is a reasonable solution IMO