### PR TITLE
Return error when unable to open file for writing.

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -643,6 +643,10 @@ cgltf_result cgltf_write_file(const cgltf_options* options, const char* path, co
 		fprintf(stderr, "Error: expected %zu bytes but wrote %zu bytes.\n", expected, actual);
 	}
 	FILE* file = fopen(path, "wt");
+	if (!file)
+	{
+		return cgltf_result_file_not_found;
+	}
 	// Note that cgltf_write() includes a null terminator, which we omit from the file content.
 	fwrite(buffer, actual - 1, 1, file);
 	fclose(file);


### PR DESCRIPTION
This is perferable to crashing and is consistent with cgltf_parse_file.