### PR TITLE
Enable JSMN_PARENT_LINKS

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -610,6 +610,9 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 #include <stdio.h>  /* For fopen */
 #include <limits.h> /* For UINT_MAX etc */
 
+/* JSMN_PARENT_LINKS is necessary to make parsing large structures linear in input size */
+#define JSMN_PARENT_LINKS
+
 /*
  * -- jsmn.h start --
  * Source: https://github.com/zserge/jsmn


### PR DESCRIPTION
This substantially improves parsing performance on large glTF files,
eliminating backtracking during parse and making parsing linear (at
least in practice) in the input size.

All tests from glTF-Sample-Models still pass; this doesn't seem to affect
fuzz safety one way or the other.

Fixes #66.