### PR TITLE
Fix memory leaks with extension lists

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -536,14 +536,14 @@ typedef struct cgltf_data
 
 	cgltf_extras extras;
 
-	const char* json;
-	cgltf_size json_size;
-
 	char** extensions_used;
 	cgltf_size extensions_used_count;
 
 	char** extensions_required;
 	cgltf_size extensions_required_count;
+
+	const char* json;
+	cgltf_size json_size;
 
 	const void* bin;
 	cgltf_size bin_size;
@@ -1394,6 +1394,9 @@ void cgltf_free(cgltf_data* data)
 	}
 
 	data->memory_free(data->memory_user_data, data->animations);
+
+	data->memory_free(data->memory_user_data, data->extensions_used);
+	data->memory_free(data->memory_user_data, data->extensions_required);
 
 	data->memory_free(data->memory_user_data, data->file_data);
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -1779,6 +1779,10 @@ static int cgltf_parse_json_string_array(cgltf_options* options, jsmntok_t const
 {
     CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_ARRAY);
     i = cgltf_parse_json_array(options, tokens, i, json_chunk, sizeof(char*), (void**)out_array, out_size);
+    if (i < 0)
+    {
+        return i;
+    }
 
     for (cgltf_size j = 0; j < *out_size; ++j)
     {

--- a/cgltf.h
+++ b/cgltf.h
@@ -1395,7 +1395,18 @@ void cgltf_free(cgltf_data* data)
 
 	data->memory_free(data->memory_user_data, data->animations);
 
+	for (cgltf_size i = 0; i < data->extensions_used_count; ++i)
+	{
+		data->memory_free(data->memory_user_data, data->extensions_used[i]);
+	}
+
 	data->memory_free(data->memory_user_data, data->extensions_used);
+
+	for (cgltf_size i = 0; i < data->extensions_required_count; ++i)
+	{
+		data->memory_free(data->memory_user_data, data->extensions_required[i]);
+	}
+
 	data->memory_free(data->memory_user_data, data->extensions_required);
 
 	data->memory_free(data->memory_user_data, data->file_data);


### PR DESCRIPTION
extensions_used/extensions_required were not being freed on exit (found
using fuzzing).

Additionally, duplicate definitions of extensionsUsed could result in further
memory leaks because of incorrect error handling during string array parse.

Also move json_data after extensions_used since this isn't part of the
actual semantical data in glTF file and is just an utility like
bin_data.