### PR TITLE
 Make parser memory-safe 🎉

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1665,44 +1665,32 @@ static cgltf_bool cgltf_json_to_bool(jsmntok_t const* tok, const uint8_t* json_c
 
 static int cgltf_skip_json(jsmntok_t const* tokens, int i)
 {
-	if (tokens[i].type == JSMN_ARRAY)
+	int end = i + 1;
+
+	while (i < end)
 	{
-		int size = tokens[i].size;
-		++i;
-		for (int j = 0; j < size; ++j)
+		switch (tokens[i].type)
 		{
-			i = cgltf_skip_json(tokens, i);
-			if (i < 0)
-			{
-				return i;
-			}
+		case JSMN_OBJECT:
+			end += tokens[i].size * 2;
+			break;
+
+		case JSMN_ARRAY:
+			end += tokens[i].size;
+			break;
+
+		case JSMN_PRIMITIVE:
+		case JSMN_STRING:
+			break;
+
+		default:
+			return -1;
 		}
-		return i;
+
+		i++;
 	}
-	else if (tokens[i].type == JSMN_OBJECT)
-	{
-		int size = tokens[i].size;
-		++i;
-		for (int j = 0; j < size; ++j)
-		{
-			CGLTF_CHECK_KEY(tokens[i]);
-			++i;
-			i = cgltf_skip_json(tokens, i);
-			if (i < 0)
-			{
-				return i;
-			}
-		}
-		return i;
-	}
-	else if (tokens[i].type == JSMN_PRIMITIVE || tokens[i].type == JSMN_STRING)
-	{
-		return i + 1;
-	}
-	else
-	{
-		return -1;
-	}
+
+	return i;
 }
 
 static void cgltf_fill_float_array(float* out_array, int size, float value)

--- a/cgltf.h
+++ b/cgltf.h
@@ -613,6 +613,9 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 /* JSMN_PARENT_LINKS is necessary to make parsing large structures linear in input size */
 #define JSMN_PARENT_LINKS
 
+/* JSMN_STRICT is necessary to reject invalid JSON documents */
+#define JSMN_STRICT
+
 /*
  * -- jsmn.h start --
  * Source: https://github.com/zserge/jsmn
@@ -1039,7 +1042,7 @@ cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, 
 				return cgltf_result_unknown_format;
 			}
 		}
-		else if (strstr(uri, "://") == NULL)
+		else if (strstr(uri, "://") == NULL && gltf_path)
 		{
 			cgltf_result res = cgltf_load_buffer_file(options, data->buffers[i].size, uri, gltf_path, &data->buffers[i].data);
 

--- a/fuzz/data/TriangleWithoutIndices.gltf
+++ b/fuzz/data/TriangleWithoutIndices.gltf
@@ -1,0 +1,53 @@
+{
+  "scenes" : [
+    {
+      "nodes" : [ 0 ]
+    }
+  ],
+  
+  "nodes" : [
+    {
+      "mesh" : 0
+    }
+  ],
+
+  "meshes" : [
+    {
+      "primitives" : [ {
+        "attributes" : {
+          "POSITION" : 0
+        }
+      } ]
+    }
+  ],
+
+  "buffers" : [
+    {
+      "uri" : "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAA",
+      "byteLength" : 36
+    }
+  ],
+  "bufferViews" : [
+    {
+      "buffer" : 0,
+      "byteOffset" : 0,
+      "byteLength" : 36,
+      "target" : 34962
+    }
+  ],
+  "accessors" : [
+    {
+      "bufferView" : 0,
+      "byteOffset" : 0,
+      "componentType" : 5126,
+      "count" : 3,
+      "type" : "VEC3",
+      "max" : [ 1.0, 1.0, 0.0 ],
+      "min" : [ 0.0, 0.0, 0.0 ]
+    }
+  ],
+  
+  "asset" : {
+    "version" : "2.0"
+  }
+}

--- a/fuzz/main.c
+++ b/fuzz/main.c
@@ -1,3 +1,10 @@
+/* How to fuzz:
+
+clang main.c -O2 -g -fsanitize=address,fuzzer -o fuzz
+cp -r data temp
+./fuzz temp/ -dict=gltf.dict -jobs=12 -workers=12
+
+*/
 #define CGLTF_IMPLEMENTATION
 #include "../cgltf.h"
 


### PR DESCRIPTION
This change makes cgltf memory-safe, at least as far as fuzzing is concerned :)

After this change I ran fuzzing for about 100 CPU-hours without any issues.
I'm not willing to prove the safety but it's definitely way better than it used to be.

There's one big problem that this change is fixing, which is that jsmn can generate non-sensical
JSON token structures. At some point it would be nice to fix the problem at its core, but for now we do the following:

1. Enable JSMN strict mode. This rejects *some* instances of malformed JSON documents, but not all of them.

2. Fix a few missing error checks in `cgltf_parse_json_texture_view` extension parsing.

3. Add an UNDEFINED token after the token stream. This makes sure that when the token stream is invalid, we will hit an UNDEFINED token which will generate a parsing error that will then propagate downstream. Of course this still relies on all error handling everywhere being correct which is somewhat fragile, but at least the fuzzer thinks we're good.

Additionally, cgltf_skip_json is now non-recursive, which means that the entire parser now has a static stack bound. This is important because previously, a JSON document with a very high nesting depth could cause a stack overflow.

Finally, cgltf_load_buffers can now work with NULL gltf_path - this means we can fuzz load_buffers without file I/O which checks Base64 decoding (I tested this a bit but I'm not adding this to the fuzzing framework yet because this requires special fuzzing setup so that memory allocation errors don't halt the fuzzing process...).