### PR TITLE
Wrong result from `cgltf_combine_paths` when `base` has no path separator

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -895,7 +895,7 @@ static void cgltf_combine_paths(char* path, const char* base, const char* uri)
 	}
 	else
 	{
-		strcpy(path, base);
+		strcpy(path, uri);
 	}
 }
 


### PR DESCRIPTION
When you have a `base` which doesn't contain a path separator, e.g. "scene.gltf", then `cgltf_combine_paths` returns the base file rather than the URI. This means `cgltf_load_buffers` will open the original GLTF file rather than the .bin containing the buffer data, leading to invalid data and possibly a crash.

Returning `uri` rather than `base` for this case fixes it.