### PR TITLE
Add #include<stdbool.h> to cgltf_write.h

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -30,6 +30,7 @@
 #include "cgltf.h"
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
On Mac OS v10.14.5, the following example won't compile when you run `gcc test.c`:
```
// test.c
#define CGLTF_WRITE_IMPLEMENTATION
#include "cgltf_write.h"

int main(void) {
	cgltf_options options = {0};
	cgltf_data data = {
		.asset = {
			.generator = "test",
			.version = "2.0"
		},
	};
	cgltf_write_file(&options, "test.gltf", &data);
	return 0;
}
```

Here are a subset of the corresponding error messages:
```
In file included from test.c:2:
./cgltf_write.h:205:92: error: unknown type name 'bool'
static void cgltf_write_boolprop_optional(cgltf_write_context* context, const char* label, bool val, bool def)
                                                                                           ^
./cgltf_write.h:205:102: error: unknown type name 'bool'
static void cgltf_write_boolprop_optional(cgltf_write_context* context, const char* label, bool val, bool def)
                                                                                                     ^
./cgltf_write.h:234:8: error: unknown type name 'bool'
static bool cgltf_check_floatarray(const float* vals, int dim, float val) {
       ^
```

Including `stdbool.h` addresses these errors and enables compilation of the example.
