### PR TITLE
Avoid warning when compiling as C99

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -423,7 +423,7 @@ typedef struct cgltf_light {
 	cgltf_float spot_outer_cone_angle;
 } cgltf_light;
 
-typedef struct cgltf_node {
+struct cgltf_node {
 	char* name;
 	cgltf_node* parent;
 	cgltf_node** children;
@@ -443,7 +443,7 @@ typedef struct cgltf_node {
 	cgltf_float scale[3];
 	cgltf_float matrix[16];
 	cgltf_extras extras;
-} cgltf_node;
+};
 
 typedef struct cgltf_scene {
 	char* name;


### PR DESCRIPTION
This commit addresses issue https://github.com/jkuhlmann/cgltf/issues/74