### PR TITLE
Fix a few corner cases in cgltf_component_read_*

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1512,9 +1512,9 @@ static cgltf_size cgltf_component_read_index(const void* in, cgltf_component_typ
 		case cgltf_component_type_r_8:
 			return *((const int8_t*) in);
 		case cgltf_component_type_r_8u:
-		case cgltf_component_type_invalid:
-		default:
 			return *((const uint8_t*) in);
+		default:
+			return 0;
 	}
 }
 
@@ -1529,18 +1529,17 @@ static cgltf_float cgltf_component_read_float(const void* in, cgltf_component_ty
 	{
 		switch (component_type)
 		{
-			case cgltf_component_type_r_32u:
-				return *((const uint32_t*) in) / (float) UINT_MAX;
+			// note: glTF spec doesn't currently define normalized conversions for 32-bit integers
 			case cgltf_component_type_r_16:
-				return *((const int16_t*) in) / (float) SHRT_MAX;
+				return *((const int16_t*) in) / (cgltf_float)32767;
 			case cgltf_component_type_r_16u:
-				return *((const uint16_t*) in) / (float) USHRT_MAX;
+				return *((const uint16_t*) in) / (cgltf_float)65535;
 			case cgltf_component_type_r_8:
-				return *((const int8_t*) in) / (float) SCHAR_MAX;
+				return *((const int8_t*) in) / (cgltf_float)127;
 			case cgltf_component_type_r_8u:
-			case cgltf_component_type_invalid:
+				return *((const uint8_t*) in) / (cgltf_float)255;
 			default:
-				return *((const uint8_t*) in) / (float) CHAR_MAX;
+				return 0;
 		}
 	}
 


### PR DESCRIPTION
This change fixes a few issues with the existing implementation:

- Normalized 8-bit unsigned integers were decoded using CHAR_MAX as the
divider; signedness of char is not specified by the standard and it's
*very* common to have char be signed (it's usually unsigned on ARM
systems and signed everywhere else), so this used 127 instead of 255

- In general it's incorrect to rely on USHRT/UCHAR/etc. limits - we are
dealing with fixed-width quantities, and in theory the short/char/etc.
could have different sizes or limits. It's more correct to hardcode the
numbers from the spec.

- glTF spec doesn't define normalization behavior for 32-bit integers.
Note that it also doesn't define a signed 32-bit integer type and it's
unlikely that one will happen without the other. This is relevant
because 2^32-1 isn't representable exactly as a float; removing the case
entirely alleviates precision concerns.

- Finally, unknown types should not be treated the same way as r8u, and
instead should return a placeholder value.