### PR TITLE
Update to documentation

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -19,8 +19,9 @@
  * this function returns `cgltf_result_success`, you have to call
  * `cgltf_free()` on the created `cgltf_data*` variable.
  * Note that contents of external files for buffers and images are not
- * automatically loaded. You'll need to read these files yourself using
- * URIs in the `cgltf_data` structure.
+ * automatically loaded because the file path can't be resolved.
+ * You'll need to read these files yourself using URIs in the
+ * `cgltf_data` structure.
  *
  * `cgltf_options` is the struct passed to `cgltf_parse()` to control
  * parts of the parsing process. You can use it to force the file type
@@ -248,7 +249,7 @@ typedef struct cgltf_accessor
 	cgltf_type type;
 	cgltf_size offset;
 	cgltf_size count;
-	cgltf_size stride;
+	cgltf_size stride; /* calculated from cgltf_calc_size */
 	cgltf_buffer_view* buffer_view;
 	cgltf_bool has_min;
 	cgltf_float min[16];


### PR DESCRIPTION
- explicitly explain why `cgltf_parse` can't load URI buffers (I was going to add the code until I realized I didn't have the full path)
- #77 small comment about where the `cgltf_accessor.stride` comes from as its not in the gltf spec itself