### PR TITLE
C99 conformance fix

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -420,7 +420,7 @@ typedef struct cgltf_camera {
 	union {
 		cgltf_camera_perspective perspective;
 		cgltf_camera_orthographic orthographic;
-	};
+	} data;
 	cgltf_extras extras;
 } cgltf_camera;
 
@@ -3284,30 +3284,30 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 				if (cgltf_json_strcmp(tokens+i, json_chunk, "aspectRatio") == 0)
 				{
 					++i;
-					out_camera->perspective.aspect_ratio = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.perspective.aspect_ratio = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "yfov") == 0)
 				{
 					++i;
-					out_camera->perspective.yfov = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.perspective.yfov = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "zfar") == 0)
 				{
 					++i;
-					out_camera->perspective.zfar = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.perspective.zfar = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "znear") == 0)
 				{
 					++i;
-					out_camera->perspective.znear = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.perspective.znear = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 				{
-					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_camera->perspective.extras);
+					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_camera->data.perspective.extras);
 				}
 				else
 				{
@@ -3338,30 +3338,30 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 				if (cgltf_json_strcmp(tokens+i, json_chunk, "xmag") == 0)
 				{
 					++i;
-					out_camera->orthographic.xmag = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.orthographic.xmag = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "ymag") == 0)
 				{
 					++i;
-					out_camera->orthographic.ymag = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.orthographic.ymag = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "zfar") == 0)
 				{
 					++i;
-					out_camera->orthographic.zfar = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.orthographic.zfar = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "znear") == 0)
 				{
 					++i;
-					out_camera->orthographic.znear = cgltf_json_to_float(tokens + i, json_chunk);
+					out_camera->data.orthographic.znear = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 				{
-					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_camera->orthographic.extras);
+					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_camera->data.orthographic.extras);
 				}
 				else
 				{

--- a/cgltf.h
+++ b/cgltf.h
@@ -1727,7 +1727,7 @@ static int cgltf_json_to_int(jsmntok_t const* tok, const uint8_t* json_chunk)
 {
 	CGLTF_CHECK_TOKTYPE(*tok, JSMN_PRIMITIVE);
 	char tmp[128];
-	int size = (cgltf_size)(tok->end - tok->start) < sizeof(tmp) ? tok->end - tok->start : sizeof(tmp) - 1;
+	int size = (cgltf_size)(tok->end - tok->start) < sizeof(tmp) ? tok->end - tok->start : (int)(sizeof(tmp) - 1);
 	strncpy(tmp, (const char*)json_chunk + tok->start, size);
 	tmp[size] = 0;
 	return atoi(tmp);
@@ -1737,7 +1737,7 @@ static cgltf_float cgltf_json_to_float(jsmntok_t const* tok, const uint8_t* json
 {
 	CGLTF_CHECK_TOKTYPE(*tok, JSMN_PRIMITIVE);
 	char tmp[128];
-	int size = (cgltf_size)(tok->end - tok->start) < sizeof(tmp) ? tok->end - tok->start : sizeof(tmp) - 1;
+	int size = (cgltf_size)(tok->end - tok->start) < sizeof(tmp) ? tok->end - tok->start : (int)(sizeof(tmp) - 1);
 	strncpy(tmp, (const char*)json_chunk + tok->start, size);
 	tmp[size] = 0;
 	return (cgltf_float)atof(tmp);
@@ -1865,7 +1865,7 @@ static int cgltf_parse_json_string_array(cgltf_options* options, jsmntok_t const
 static void cgltf_parse_attribute_type(const char* name, cgltf_attribute_type* out_type, int* out_index)
 {
 	const char* us = strchr(name, '_');
-	size_t len = us ? us - name : strlen(name);
+	size_t len = us ? (size_t)(us - name) : strlen(name);
 
 	if (len == 8 && strncmp(name, "POSITION", 8) == 0)
 	{

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -83,8 +83,8 @@ typedef struct {
 	uint32_t extension_flags;
 } cgltf_write_context;
 
-#define CGLTF_SPRINTF(fmt, ...) { \
-		context->tmp = snprintf ( context->cursor, context->remaining, fmt, ## __VA_ARGS__ ); \
+#define CGLTF_SPRINTF(...) { \
+		context->tmp = snprintf ( context->cursor, context->remaining, __VA_ARGS__ ); \
 		context->chars_written += context->tmp; \
 		if (context->cursor) { \
 			context->cursor += context->tmp; \
@@ -722,19 +722,19 @@ static void cgltf_write_camera(cgltf_write_context* context, const cgltf_camera*
 	if (camera->type == cgltf_camera_type_orthographic)
 	{
 		cgltf_write_line(context, "\"orthographic\": {");
-		cgltf_write_floatprop(context, "xmag", camera->orthographic.xmag, -1.0f);
-		cgltf_write_floatprop(context, "ymag", camera->orthographic.ymag, -1.0f);
-		cgltf_write_floatprop(context, "zfar", camera->orthographic.zfar, -1.0f);
-		cgltf_write_floatprop(context, "znear", camera->orthographic.znear, -1.0f);
+		cgltf_write_floatprop(context, "xmag", camera->data.orthographic.xmag, -1.0f);
+		cgltf_write_floatprop(context, "ymag", camera->data.orthographic.ymag, -1.0f);
+		cgltf_write_floatprop(context, "zfar", camera->data.orthographic.zfar, -1.0f);
+		cgltf_write_floatprop(context, "znear", camera->data.orthographic.znear, -1.0f);
 		cgltf_write_line(context, "}");
 	}
 	else if (camera->type == cgltf_camera_type_perspective)
 	{
 		cgltf_write_line(context, "\"perspective\": {");
-		cgltf_write_floatprop(context, "aspectRatio", camera->perspective.aspect_ratio, -1.0f);
-		cgltf_write_floatprop(context, "yfov", camera->perspective.yfov, -1.0f);
-		cgltf_write_floatprop(context, "zfar", camera->perspective.zfar, -1.0f);
-		cgltf_write_floatprop(context, "znear", camera->perspective.znear, -1.0f);
+		cgltf_write_floatprop(context, "aspectRatio", camera->data.perspective.aspect_ratio, -1.0f);
+		cgltf_write_floatprop(context, "yfov", camera->data.perspective.yfov, -1.0f);
+		cgltf_write_floatprop(context, "zfar", camera->data.perspective.zfar, -1.0f);
+		cgltf_write_floatprop(context, "znear", camera->data.perspective.znear, -1.0f);
 		cgltf_write_line(context, "}");
 	}
 	cgltf_write_line(context, "}");

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -99,7 +99,7 @@ typedef struct {
 #define CGLTF_WRITE_IDXARRPROP(label, dim, vals, start) if (vals) { \
 		cgltf_write_indent(context); \
 		CGLTF_SPRINTF("\"%s\": [", label); \
-		for (int i = 0; i < dim; ++i) { \
+		for (int i = 0; i < (int)(dim); ++i) { \
 			int idx = (int) (vals[i] - start); \
 			if (i != 0) CGLTF_SPRINTF(","); \
 			CGLTF_SPRINTF(" %d", idx); \
@@ -787,6 +787,7 @@ cgltf_result cgltf_write_file(const cgltf_options* options, const char* path, co
 
 cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size size, const cgltf_data* data)
 {
+	(void)options;
 	cgltf_write_context ctx;
 	ctx.buffer = buffer;
 	ctx.buffer_size = size;


### PR DESCRIPTION
There are some minor, but annoying issues when compiling cgltf with `gcc` **8.3.1**:

- The source code uses unnamed unions (for perspective and orthographic cameras), which is not legal C99, and `gcc` gives the warning (with `-pedantic`):
```
cgltf.h:423:3: warning: ISO C99 doesn’t support unnamed structs/unions [-Wpedantic]
```

- There are implicit signed/unsigned conversions that trigger warnings when compiling with `-Wextra`:
```
cgltf.h: In function ‘cgltf_json_to_int’:
cgltf.h:1730:65: warning: operand of ?: changes signedness from ‘int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
  int size = (cgltf_size)(tok->end - tok->start) < sizeof(tmp) ? tok->end - tok->start : sizeof(tmp) - 1;
                                                                 ^~~~~~~~~~~~~~~~~~~~~
cgltf.h: In function ‘cgltf_json_to_float’:
cgltf.h:1740:65: warning: operand of ?: changes signedness from ‘int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
  int size = (cgltf_size)(tok->end - tok->start) < sizeof(tmp) ? tok->end - tok->start : sizeof(tmp) - 1;
                                                                 ^~~~~~~~~~~~~~~~~~~~~
cgltf.h: In function ‘cgltf_parse_attribute_type’:
cgltf.h:1868:20: warning: operand of ?: changes signedness from ‘long int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
  size_t len = us ? us - name : strlen(name);
```

This version fixes these two issues. There are two commits: one for the first, and another for the second, in case you only care about one.