### PR TITLE
Correct light color property name

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -801,7 +801,7 @@ static void cgltf_write_light(cgltf_write_context* context, const cgltf_light* l
 	}
 	if (cgltf_check_floatarray(light->color, 3, 1.0f))
 	{
-		cgltf_write_floatarrayprop(context, "light", light->color, 3);
+		cgltf_write_floatarrayprop(context, "color", light->color, 3);
 	}
 	cgltf_write_floatprop(context, "intensity", light->intensity, 1.0f);
 	cgltf_write_floatprop(context, "range", light->range, 0.0f);


### PR DESCRIPTION
The property name for a light's color is currently `light` but it should be `color`.