### PR TITLE
Changed file operations to use callbacks.

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -993,7 +993,7 @@ static cgltf_result cgltf_load_buffer_file(const cgltf_options* options, cgltf_s
 
 	void* file_data = NULL;
 	cgltf_result result = file_read(options, path, &size, &file_data);
-	if (result >= cgltf_result_success)
+	if (result != cgltf_result_success)
 	{
 		return result;
 	}

--- a/cgltf.h
+++ b/cgltf.h
@@ -24,8 +24,8 @@
  *
  * `cgltf_options` is the struct passed to `cgltf_parse()` to control
  * parts of the parsing process. You can use it to force the file type
- * and provide memory allocation callbacks. Should be zero-initialized
- * to trigger default behavior.
+ * and provide memory allocation as well as file operation callbacks. 
+ * Should be zero-initialized to trigger default behavior.
  *
  * `cgltf_data` is the struct allocated and filled by `cgltf_parse()`.
  * It generally mirrors the glTF format as described by the spec (see


### PR DESCRIPTION
The `FILE*` operations are still used by default, but it's now configurable via `cgltf_options` how the (file) data is read and freed.

This is supposed to fix #94 .