### PR TITLE
Add intellisense support in CLion

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -632,8 +632,8 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
  *
  */
 
-#ifdef __INTELLISENSE__
-/* This makes MSVC intellisense work. */
+#if defined(__INTELLISENSE__) || defined(__JETBRAINS_IDE__)
+/* This makes MSVC/CLion intellisense work. */
 #define CGLTF_IMPLEMENTATION
 #endif
 

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -57,9 +57,9 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
  *
  */
 
-#ifdef __INTELLISENSE__
-/* This makes MSVC intellisense work. */
-#define CGLTF_WRITE_IMPLEMENTATION
+#if defined(__INTELLISENSE__) || defined(__JETBRAINS_IDE__)
+/* This makes MSVC/CLion intellisense work. */
+#define CGLTF_IMPLEMENTATION
 #endif
 
 #ifdef CGLTF_WRITE_IMPLEMENTATION


### PR DESCRIPTION
When `__INTELLISENSE__` is defined, `cgltf.h` turns on `CGLTF_IMPLEMENTATION`
to enable code completion, etc. in MSVC. This change does the same for
JetBrain's CLion.