### PR TITLE
Add support for KHR_draco_mesh_compression

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -386,9 +386,9 @@ typedef struct cgltf_morph_target {
 } cgltf_morph_target;
 
 typedef struct cgltf_draco_mesh_compression {
-    cgltf_buffer_view* buffer_view;
-    cgltf_attribute* attributes;
-    cgltf_size attributes_count;
+	cgltf_buffer_view* buffer_view;
+	cgltf_attribute* attributes;
+	cgltf_size attributes_count;
 } cgltf_draco_mesh_compression;
 
 typedef struct cgltf_primitive {
@@ -400,8 +400,8 @@ typedef struct cgltf_primitive {
 	cgltf_morph_target* targets;
 	cgltf_size targets_count;
 	cgltf_extras extras;
-    cgltf_bool has_draco_mesh_compression;
-    cgltf_draco_mesh_compression draco_mesh_compression;
+	cgltf_bool has_draco_mesh_compression;
+	cgltf_draco_mesh_compression draco_mesh_compression;
 } cgltf_primitive;
 
 typedef struct cgltf_mesh {
@@ -2179,28 +2179,28 @@ static int cgltf_parse_json_extras(jsmntok_t const* tokens, int i, const uint8_t
 
 static int cgltf_parse_json_draco_mesh_compression(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_draco_mesh_compression* out_draco_mesh_compression)
 {
-    CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
-    int size = tokens[i].size;
-    ++i;
+	int size = tokens[i].size;
+	++i;
 
-    for (int j = 0; j < size; ++j)
-    {
-        CGLTF_CHECK_KEY(tokens[i]);
+	for (int j = 0; j < size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
 
-        if (cgltf_json_strcmp(tokens + i, json_chunk, "attributes") == 0)
-        {
-            i = cgltf_parse_json_attribute_list(options, tokens, i + 1, json_chunk, &out_draco_mesh_compression->attributes, &out_draco_mesh_compression->attributes_count);
-        }
-        else if (cgltf_json_strcmp(tokens + i, json_chunk, "bufferView") == 0)
-        {
-            ++i;
-            out_draco_mesh_compression->buffer_view = CGLTF_PTRINDEX(cgltf_buffer_view, cgltf_json_to_int(tokens + i, json_chunk));
-            ++i;
-        }
-    }
+		if (cgltf_json_strcmp(tokens + i, json_chunk, "attributes") == 0)
+		{
+			i = cgltf_parse_json_attribute_list(options, tokens, i + 1, json_chunk, &out_draco_mesh_compression->attributes, &out_draco_mesh_compression->attributes_count);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "bufferView") == 0)
+		{
+			++i;
+			out_draco_mesh_compression->buffer_view = CGLTF_PTRINDEX(cgltf_buffer_view, cgltf_json_to_int(tokens + i, json_chunk));
+			++i;
+		}
+	}
 
-    return i;
+	return i;
 }
 
 static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_primitive* out_prim)
@@ -2261,35 +2261,35 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_prim->extras);
 		}
-        else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
-        {
-            ++i;
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
 
-            CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
-            int extensions_size = tokens[i].size;
-            ++i;
+			int extensions_size = tokens[i].size;
+			++i;
 
-            for (int k = 0; k < extensions_size; ++k)
-            {
-                CGLTF_CHECK_KEY(tokens[i]);
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
 
-                if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_draco_mesh_compression") == 0)
-                {
-                    out_prim->has_draco_mesh_compression = 1;
-                    i = cgltf_parse_json_draco_mesh_compression(options, tokens, i + 1, json_chunk, &out_prim->draco_mesh_compression);
-                }
-                else
-                {
-                    i = cgltf_skip_json(tokens, i+1);
-                }
+				if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_draco_mesh_compression") == 0)
+				{
+					out_prim->has_draco_mesh_compression = 1;
+					i = cgltf_parse_json_draco_mesh_compression(options, tokens, i + 1, json_chunk, &out_prim->draco_mesh_compression);
+				}
+				else
+				{
+					i = cgltf_skip_json(tokens, i+1);
+				}
 
-                if (i < 0)
-                {
-                    return i;
-                }
-            }
-        }
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -4645,13 +4645,13 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 				}
 			}
 
-            if (data->meshes[i].primitives[j].has_draco_mesh_compression) {
-                CGLTF_PTRFIXUP_REQ(data->meshes[i].primitives[j].draco_mesh_compression.buffer_view, data->buffer_views, data->buffer_views_count);
+			if (data->meshes[i].primitives[j].has_draco_mesh_compression) {
+				CGLTF_PTRFIXUP_REQ(data->meshes[i].primitives[j].draco_mesh_compression.buffer_view, data->buffer_views, data->buffer_views_count);
 				for (cgltf_size m = 0; m < data->meshes[i].primitives[j].draco_mesh_compression.attributes_count; ++m)
 				{
 					CGLTF_PTRFIXUP_REQ(data->meshes[i].primitives[j].draco_mesh_compression.attributes[m].data, data->accessors, data->accessors_count);
 				}
-            }
+			}
 		}
 	}
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -2572,7 +2572,6 @@ static int cgltf_parse_json_accessor(jsmntok_t const* tokens, int i, const uint8
 		{
 			++i;
 			out_accessor->buffer_view = CGLTF_PTRINDEX(cgltf_buffer_view, cgltf_json_to_int(tokens + i, json_chunk));
-            printf("bufferView = %p\n", out_accessor->buffer_view);
 			++i;
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "byteOffset") == 0)

--- a/cgltf.h
+++ b/cgltf.h
@@ -385,6 +385,12 @@ typedef struct cgltf_morph_target {
 	cgltf_size attributes_count;
 } cgltf_morph_target;
 
+typedef struct cgltf_draco_mesh_compression {
+    cgltf_buffer_view* buffer_view;
+    cgltf_attribute* attributes;
+    cgltf_size attributes_count;
+} cgltf_draco_mesh_compression;
+
 typedef struct cgltf_primitive {
 	cgltf_primitive_type type;
 	cgltf_accessor* indices;
@@ -394,6 +400,8 @@ typedef struct cgltf_primitive {
 	cgltf_morph_target* targets;
 	cgltf_size targets_count;
 	cgltf_extras extras;
+    cgltf_bool has_draco_mesh_compression;
+    cgltf_draco_mesh_compression draco_mesh_compression;
 } cgltf_primitive;
 
 typedef struct cgltf_mesh {
@@ -2169,6 +2177,32 @@ static int cgltf_parse_json_extras(jsmntok_t const* tokens, int i, const uint8_t
 	return i;
 }
 
+static int cgltf_parse_json_draco_mesh_compression(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_draco_mesh_compression* out_draco_mesh_compression)
+{
+    CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+    int size = tokens[i].size;
+    ++i;
+
+    for (int j = 0; j < size; ++j)
+    {
+        CGLTF_CHECK_KEY(tokens[i]);
+
+        if (cgltf_json_strcmp(tokens + i, json_chunk, "attributes") == 0)
+        {
+            i = cgltf_parse_json_attribute_list(options, tokens, i + 1, json_chunk, &out_draco_mesh_compression->attributes, &out_draco_mesh_compression->attributes_count);
+        }
+        else if (cgltf_json_strcmp(tokens + i, json_chunk, "bufferView") == 0)
+        {
+            ++i;
+            out_draco_mesh_compression->buffer_view = CGLTF_PTRINDEX(cgltf_buffer_view, cgltf_json_to_int(tokens + i, json_chunk));
+            ++i;
+        }
+    }
+
+    return i;
+}
+
 static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_primitive* out_prim)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -2227,6 +2261,35 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_prim->extras);
 		}
+        else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+        {
+            ++i;
+
+            CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+            int extensions_size = tokens[i].size;
+            ++i;
+
+            for (int k = 0; k < extensions_size; ++k)
+            {
+                CGLTF_CHECK_KEY(tokens[i]);
+
+                if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_draco_mesh_compression") == 0)
+                {
+                    out_prim->has_draco_mesh_compression = 1;
+                    i = cgltf_parse_json_draco_mesh_compression(options, tokens, i + 1, json_chunk, &out_prim->draco_mesh_compression);
+                }
+                else
+                {
+                    i = cgltf_skip_json(tokens, i+1);
+                }
+
+                if (i < 0)
+                {
+                    return i;
+                }
+            }
+        }
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -2509,6 +2572,7 @@ static int cgltf_parse_json_accessor(jsmntok_t const* tokens, int i, const uint8
 		{
 			++i;
 			out_accessor->buffer_view = CGLTF_PTRINDEX(cgltf_buffer_view, cgltf_json_to_int(tokens + i, json_chunk));
+            printf("bufferView = %p\n", out_accessor->buffer_view);
 			++i;
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "byteOffset") == 0)
@@ -4581,6 +4645,14 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 					CGLTF_PTRFIXUP_REQ(data->meshes[i].primitives[j].targets[k].attributes[m].data, data->accessors, data->accessors_count);
 				}
 			}
+
+            if (data->meshes[i].primitives[j].has_draco_mesh_compression) {
+                CGLTF_PTRFIXUP_REQ(data->meshes[i].primitives[j].draco_mesh_compression.buffer_view, data->buffer_views, data->buffer_views_count);
+				for (cgltf_size m = 0; m < data->meshes[i].primitives[j].draco_mesh_compression.attributes_count; ++m)
+				{
+					CGLTF_PTRFIXUP_REQ(data->meshes[i].primitives[j].draco_mesh_compression.attributes[m].data, data->accessors, data->accessors_count);
+				}
+            }
 		}
 	}
 

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -410,28 +410,28 @@ static void cgltf_write_primitive(cgltf_write_context* context, const cgltf_prim
 
 	cgltf_bool has_extensions = prim->has_draco_mesh_compression;
 	if (has_extensions) {
-        cgltf_write_line(context, "\"extensions\": {");
+		cgltf_write_line(context, "\"extensions\": {");
 
-        if (prim->has_draco_mesh_compression) {
-            context->extension_flags |= CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION;
-            if (prim->attributes_count == 0 || prim->indices == 0) {
-                context->required_extension_flags |= CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION;                
-            }
+		if (prim->has_draco_mesh_compression) {
+			context->extension_flags |= CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION;
+			if (prim->attributes_count == 0 || prim->indices == 0) {
+				context->required_extension_flags |= CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION;				 
+			}
 
-            cgltf_write_line(context, "\"KHR_draco_mesh_compression\": {");
-            CGLTF_WRITE_IDXPROP("bufferView", prim->draco_mesh_compression.buffer_view, context->data->buffer_views);
-            cgltf_write_line(context, "\"attributes\": {");
-            for (cgltf_size i = 0; i < prim->draco_mesh_compression.attributes_count; ++i)
-            {
-                const cgltf_attribute* attr = prim->draco_mesh_compression.attributes + i;
-                CGLTF_WRITE_IDXPROP(attr->name, attr->data, context->data->accessors);
-            }
-            cgltf_write_line(context, "}");
-            cgltf_write_line(context, "}");
-        }
+			cgltf_write_line(context, "\"KHR_draco_mesh_compression\": {");
+			CGLTF_WRITE_IDXPROP("bufferView", prim->draco_mesh_compression.buffer_view, context->data->buffer_views);
+			cgltf_write_line(context, "\"attributes\": {");
+			for (cgltf_size i = 0; i < prim->draco_mesh_compression.attributes_count; ++i)
+			{
+				const cgltf_attribute* attr = prim->draco_mesh_compression.attributes + i;
+				CGLTF_WRITE_IDXPROP(attr->name, attr->data, context->data->accessors);
+			}
+			cgltf_write_line(context, "}");
+			cgltf_write_line(context, "}");
+		}
 
-        cgltf_write_line(context, "}");
-    }
+		cgltf_write_line(context, "}");
+	}
 }
 
 static void cgltf_write_mesh(cgltf_write_context* context, const cgltf_mesh* mesh)
@@ -1054,13 +1054,13 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 
 	if (context->extension_flags != 0) {
 		cgltf_write_line(context, "\"extensionsUsed\": [");
-        cgltf_write_extensions(context, context->extension_flags);
+		cgltf_write_extensions(context, context->extension_flags);
 		cgltf_write_line(context, "]");
 	}
 
 	if (context->required_extension_flags != 0) {
 		cgltf_write_line(context, "\"extensionsRequired\": [");
-        cgltf_write_extensions(context, context->required_extension_flags);
+		cgltf_write_extensions(context, context->required_extension_flags);
 		cgltf_write_line(context, "]");
 	}
 

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -69,10 +69,11 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #include <stdlib.h>
 #include <string.h>
 
-#define CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM   (1 << 0)
-#define CGLTF_EXTENSION_FLAG_MATERIALS_UNLIT     (1 << 1)
-#define CGLTF_EXTENSION_FLAG_SPECULAR_GLOSSINESS (1 << 2)
-#define CGLTF_EXTENSION_FLAG_LIGHTS_PUNCTUAL     (1 << 3)
+#define CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM      (1 << 0)
+#define CGLTF_EXTENSION_FLAG_MATERIALS_UNLIT        (1 << 1)
+#define CGLTF_EXTENSION_FLAG_SPECULAR_GLOSSINESS    (1 << 2)
+#define CGLTF_EXTENSION_FLAG_LIGHTS_PUNCTUAL        (1 << 3)
+#define CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION (1 << 4)
 
 typedef struct {
 	char* buffer;
@@ -86,6 +87,7 @@ typedef struct {
 	const char* indent;
 	int needs_comma;
 	uint32_t extension_flags;
+	uint32_t required_extension_flags;
 } cgltf_write_context;
 
 #define CGLTF_MIN(a, b) (a < b ? a : b)
@@ -405,6 +407,31 @@ static void cgltf_write_primitive(cgltf_write_context* context, const cgltf_prim
 		cgltf_write_line(context, "]");
 	}
 	cgltf_write_extras(context, &prim->extras);
+
+	cgltf_bool has_extensions = prim->has_draco_mesh_compression;
+	if (has_extensions) {
+        cgltf_write_line(context, "\"extensions\": {");
+
+        if (prim->has_draco_mesh_compression) {
+            context->extension_flags |= CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION;
+            if (prim->attributes_count == 0 || prim->indices == 0) {
+                context->required_extension_flags |= CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION;                
+            }
+
+            cgltf_write_line(context, "\"KHR_draco_mesh_compression\": {");
+            CGLTF_WRITE_IDXPROP("bufferView", prim->draco_mesh_compression.buffer_view, context->data->buffer_views);
+            cgltf_write_line(context, "\"attributes\": {");
+            for (cgltf_size i = 0; i < prim->draco_mesh_compression.attributes_count; ++i)
+            {
+                const cgltf_attribute* attr = prim->draco_mesh_compression.attributes + i;
+                CGLTF_WRITE_IDXPROP(attr->name, attr->data, context->data->accessors);
+            }
+            cgltf_write_line(context, "}");
+            cgltf_write_line(context, "}");
+        }
+
+        cgltf_write_line(context, "}");
+    }
 }
 
 static void cgltf_write_mesh(cgltf_write_context* context, const cgltf_mesh* mesh)
@@ -836,6 +863,26 @@ cgltf_result cgltf_write_file(const cgltf_options* options, const char* path, co
 	return cgltf_result_success;
 }
 
+
+static void cgltf_write_extensions(cgltf_write_context* context, uint32_t extension_flags)
+{
+	if (extension_flags & CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM) {
+		cgltf_write_stritem(context, "KHR_texture_transform");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_UNLIT) {
+		cgltf_write_stritem(context, "KHR_materials_unlit");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_SPECULAR_GLOSSINESS) {
+		cgltf_write_stritem(context, "KHR_materials_pbrSpecularGlossiness");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_LIGHTS_PUNCTUAL) {
+		cgltf_write_stritem(context, "KHR_lights_punctual");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION) {
+		cgltf_write_stritem(context, "KHR_draco_mesh_compression");
+	}
+}
+
 cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size size, const cgltf_data* data)
 {
 	(void)options;
@@ -850,6 +897,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 	ctx.indent = "  ";
 	ctx.needs_comma = 0;
 	ctx.extension_flags = 0;
+	ctx.required_extension_flags = 0;
 
 	cgltf_write_context* context = &ctx;
 
@@ -1007,18 +1055,13 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 
 	if (context->extension_flags != 0) {
 		cgltf_write_line(context, "\"extensionsUsed\": [");
-		if (context->extension_flags & CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM) {
-			cgltf_write_stritem(context, "KHR_texture_transform");
-		}
-		if (context->extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_UNLIT) {
-			cgltf_write_stritem(context, "KHR_materials_unlit");
-		}
-		if (context->extension_flags & CGLTF_EXTENSION_FLAG_SPECULAR_GLOSSINESS) {
-			cgltf_write_stritem(context, "KHR_materials_pbrSpecularGlossiness");
-		}
-		if (context->extension_flags & CGLTF_EXTENSION_FLAG_LIGHTS_PUNCTUAL) {
-			cgltf_write_stritem(context, "KHR_lights_punctual");
-		}
+        cgltf_write_extensions(context, context->extension_flags);
+		cgltf_write_line(context, "]");
+	}
+
+	if (context->required_extension_flags != 0) {
+		cgltf_write_line(context, "\"extensionsRequired\": [");
+        cgltf_write_extensions(context, context->required_extension_flags);
 		cgltf_write_line(context, "]");
 	}
 

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -863,7 +863,6 @@ cgltf_result cgltf_write_file(const cgltf_options* options, const char* path, co
 	return cgltf_result_success;
 }
 
-
 static void cgltf_write_extensions(cgltf_write_context* context, uint32_t extension_flags)
 {
 	if (extension_flags & CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM) {


### PR DESCRIPTION
This change adds support to read and write glTF files that use
the `KHR_draco_mesh_compression` extension. The extension can be
specified per primitive, which is why cgltf_primitive now has 2
new fields: `has_draco_mesh_compression` and `draco_mesh_compression`.
`draco_mesh_compression` contains a buffer view and a list of
attributes.

It is important to note that the extension may or may not be
required. A primitive can specify both compressed and uncompressed
data. While this doesn't affect the parsing, it does affect the
writing since the proper extensionsUsed/Required needs to be
specified. To achieve this, this change adds support for required
extensions in `cgltf_write.h` (see `required_extensions_flag` in
`cgltf_context`). The extension is deemed required when a primitive
has no attributes or no indices.

Please refer to the [extension spec](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression).