### PR TITLE
Add support for KHR_materials_clearcoat

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -74,6 +74,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #define CGLTF_EXTENSION_FLAG_SPECULAR_GLOSSINESS    (1 << 2)
 #define CGLTF_EXTENSION_FLAG_LIGHTS_PUNCTUAL        (1 << 3)
 #define CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION (1 << 4)
+#define CGLTF_EXTENSION_FLAG_MATERIALS_CLEARCOAT    (1 << 5)
 
 typedef struct {
 	char* buffer;
@@ -512,9 +513,20 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		cgltf_write_line(context, "}");
 	}
 
-	if (material->unlit || material->has_pbr_specular_glossiness)
+	if (material->unlit || material->has_pbr_specular_glossiness || material->has_clearcoat)
 	{
 		cgltf_write_line(context, "\"extensions\": {");
+		if (material->has_clearcoat)
+		{
+			const cgltf_clearcoat* params = &material->clearcoat;
+			cgltf_write_line(context, "\"KHR_materials_clearcoat\": {");
+			CGLTF_WRITE_TEXTURE_INFO("clearcoatTexture", params->clearcoat_texture);
+			CGLTF_WRITE_TEXTURE_INFO("clearcoatRoughnessTexture", params->clearcoat_roughness_texture);
+			CGLTF_WRITE_TEXTURE_INFO("clearcoatNormalTexture", params->clearcoat_normal_texture);
+			cgltf_write_floatprop(context, "clearcoatFactor", params->clearcoat_factor, 0.0f);
+			cgltf_write_floatprop(context, "clearcoatRoughnessFactor", params->clearcoat_roughness_factor, 0.0f);
+			cgltf_write_line(context, "}");
+		}
 		if (material->has_pbr_specular_glossiness)
 		{
 			const cgltf_pbr_specular_glossiness* params = &material->pbr_specular_glossiness;
@@ -879,6 +891,9 @@ static void cgltf_write_extensions(cgltf_write_context* context, uint32_t extens
 	}
 	if (extension_flags & CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION) {
 		cgltf_write_stritem(context, "KHR_draco_mesh_compression");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_CLEARCOAT) {
+		cgltf_write_stritem(context, "KHR_materials_clearcoat");
 	}
 }
 

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -497,6 +497,11 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		context->extension_flags |= CGLTF_EXTENSION_FLAG_SPECULAR_GLOSSINESS;
 	}
 
+	if (material->has_clearcoat)
+	{
+		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_CLEARCOAT;
+	}
+
 	if (material->has_pbr_metallic_roughness)
 	{
 		const cgltf_pbr_metallic_roughness* params = &material->pbr_metallic_roughness;


### PR DESCRIPTION
This extension has entered the ratification process. The current
draft can be found at https://github.com/KhronosGroup/glTF/pull/1756/.

It is very likely that the extension will be accepted as is.