### PR TITLE
Easier access to vendor/unsupported extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cgltf also supports some glTF extensions:
 - KHR_texture_transform
 - KHR_draco_mesh_compression (requires a library like [Google's Draco](https://github.com/google/draco) for decompression though)
 
-cgltf does **not** yet support unlisted extensions.
+cgltf does **not** yet support unlisted extensions. However, unlisted extensions can be accessed via "extensions" member on objects.
 
 ## Building
 The easiest approach is to integrate the `cgltf.h` header file into your project. If you are unfamiliar with single-file C libraries (also known as stb-style libraries), this is how it goes:

--- a/cgltf.h
+++ b/cgltf.h
@@ -2832,7 +2832,7 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 
 					++i;
 
-					for (int k = 0; k < extensions_size; ++k)
+					for (int l = 0; l < extensions_size; ++l)
 					{
 						CGLTF_CHECK_KEY(tokens[i]);
 
@@ -2895,7 +2895,7 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 
 					++i;
 
-					for (int k = 0; k < extensions_size; ++k)
+					for (int l = 0; l < extensions_size; ++l)
 					{
 						CGLTF_CHECK_KEY(tokens[i]);
 
@@ -4892,7 +4892,7 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 
 					++i;
 
-					for (int k = 0; k < extensions_size; ++k)
+					for (int l = 0; l < extensions_size; ++l)
 					{
 						CGLTF_CHECK_KEY(tokens[i]);
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -3701,8 +3701,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 			int extensions_size = tokens[i].size;
 			++i;
 			out_material->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
-
-			int unhandled_extensions = 0;
+			out_material->extensions_count= 0;
 
 			for (int k = 0; k < extensions_size; ++k)
 			{
@@ -3725,16 +3724,14 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				}
 				else
 				{
-					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_material->extensions[unhandled_extensions++]));
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_material->extensions[out_material->extensions_count++]));
 				}
 
 				if (i < 0)
 				{
-					out_material->extensions_count = unhandled_extensions;
 					return i;
 				}
 			}
-			out_material->extensions_count = unhandled_extensions;
 		}
 		else
 		{

--- a/cgltf.h
+++ b/cgltf.h
@@ -1682,6 +1682,25 @@ void cgltf_free(cgltf_data* data)
 			data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions);
 		}
 
+		for (cgltf_size j = 0; j < data->materials[i].normal_texture.extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->materials[i].normal_texture.extensions[j].name);
+			data->memory.free(data->memory.user_data, data->materials[i].normal_texture.extensions[j].data);
+		}
+		data->memory.free(data->memory.user_data, data->materials[i].normal_texture.extensions);
+		for (cgltf_size j = 0; j < data->materials[i].occlusion_texture.extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->materials[i].occlusion_texture.extensions[j].name);
+			data->memory.free(data->memory.user_data, data->materials[i].occlusion_texture.extensions[j].data);
+		}
+		data->memory.free(data->memory.user_data, data->materials[i].occlusion_texture.extensions);
+		for (cgltf_size j = 0; j < data->materials[i].emissive_texture.extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->materials[i].emissive_texture.extensions[j].name);
+			data->memory.free(data->memory.user_data, data->materials[i].emissive_texture.extensions[j].data);
+		}
+		data->memory.free(data->memory.user_data, data->materials[i].emissive_texture.extensions);
+
 		for (cgltf_size j = 0; j < data->materials[i].extensions_count; ++j)
 		{
 			data->memory.free(data->memory.user_data, data->materials[i].extensions[j].name);
@@ -2467,6 +2486,7 @@ static int cgltf_parse_json_extras(jsmntok_t const* tokens, int i, const uint8_t
 static int cgltf_parse_json_unprocessed_extension(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_extension* out_extension)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_STRING);
+	CGLTF_CHECK_TOKTYPE(tokens[i+1], JSMN_OBJECT);
 	if (out_extension->name)
 	{
 		return CGLTF_ERROR_JSON;

--- a/cgltf.h
+++ b/cgltf.h
@@ -88,14 +88,6 @@
  * into the provided buffer. If `dest` is NULL, the length of the data is written into
  * `dest_size`. You can then parse this data using your own JSON parser
  * or, if you've included the cgltf implementation using the integrated JSMN JSON parser.
- *
- * `cgltf_result cgltf_copy_extension_json(const cgltf_data* data, const cgltf_extension* extension,
- * char* dest, cgltf_size* dest_size)` allows users to retrieve the JSON data for extension that
- * hasn't been processed by cgltf. The `cgltf_extension` struct stores name of extension and the
- * offsets of the start and end of the extension JSON data as it appears in the complete glTF JSON
- * data. This function copies the extension data into the provided buffer. If `dest` is NULL,
- * the length of the data is written into `dest_size`. You can then parse this data using your own
- * JSON parser or, if you've included the cgltf implementation using the integrated JSMN JSON parser.
  */
 #ifndef CGLTF_H_INCLUDED__
 #define CGLTF_H_INCLUDED__

--- a/cgltf.h
+++ b/cgltf.h
@@ -2468,6 +2468,12 @@ static int cgltf_parse_json_extras(jsmntok_t const* tokens, int i, const uint8_t
 
 static int cgltf_parse_json_unprocessed_extension(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_extension* out_extension)
 {
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_STRING);
+	if (out_extension->name)
+	{
+		return CGLTF_ERROR_JSON;
+	}
+
 	cgltf_size name_length = tokens[i].end - tokens[i].start;
 	out_extension->name = (char*)options->memory.alloc(options->memory.user_data, name_length + 1);
 	strncpy(out_extension->name, (const char*)json_chunk + tokens[i].start, name_length);
@@ -2571,10 +2577,14 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_prim->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_prim->extensions_count = 0;
-			out_prim->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_prim->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 			for (int k = 0; k < extensions_size; ++k)
@@ -2694,10 +2704,14 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_mesh->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_mesh->extensions_count = 0;
-			out_mesh->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_mesh->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -2825,10 +2839,14 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					++i;
 
 					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+					if(out_sparse->indices_extensions)
+					{
+						return CGLTF_ERROR_JSON;
+					}
 
 					int extensions_size = tokens[i].size;
 					out_sparse->indices_extensions_count = 0;
-					out_sparse->indices_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+					out_sparse->indices_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 					++i;
 
@@ -2888,10 +2906,14 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					++i;
 
 					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+					if(out_sparse->values_extensions)
+					{
+						return CGLTF_ERROR_JSON;
+					}
 
 					int extensions_size = tokens[i].size;
 					out_sparse->values_extensions_count = 0;
-					out_sparse->values_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+					out_sparse->values_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 					++i;
 
@@ -2927,10 +2949,14 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_sparse->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_sparse->extensions_count = 0;
-			out_sparse->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_sparse->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -3066,10 +3092,14 @@ static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* to
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_accessor->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_accessor->extensions_count = 0;
-			out_accessor->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_accessor->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -3191,10 +3221,14 @@ static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_texture_view->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_texture_view->extensions_count = 0;
-			out_texture_view->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_texture_view->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -3421,10 +3455,14 @@ static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* token
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_image->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_image->extensions_count = 0;
-			out_image->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_image->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -3506,10 +3544,14 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_sampler->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_sampler->extensions_count = 0;
-			out_sampler->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_sampler->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -3576,10 +3618,14 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_texture->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_texture->extensions_count = 0;
-			out_texture->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_texture->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -3697,10 +3743,14 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_material->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			++i;
-			out_material->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_material->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 			out_material->extensions_count= 0;
 
 			for (int k = 0; k < extensions_size; ++k)
@@ -3908,10 +3958,14 @@ static int cgltf_parse_json_buffer_view(cgltf_options* options, jsmntok_t const*
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_buffer_view->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_buffer_view->extensions_count = 0;
-			out_buffer_view->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_buffer_view->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -3991,10 +4045,14 @@ static int cgltf_parse_json_buffer(cgltf_options* options, jsmntok_t const* toke
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_buffer->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_buffer->extensions_count = 0;
-			out_buffer->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_buffer->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -4095,10 +4153,14 @@ static int cgltf_parse_json_skin(cgltf_options* options, jsmntok_t const* tokens
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_skin->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_skin->extensions_count = 0;
-			out_skin->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_skin->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -4292,10 +4354,14 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_camera->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_camera->extensions_count = 0;
-			out_camera->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_camera->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -4559,10 +4625,14 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_node->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_node->extensions_count= 0;
-			out_node->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_node->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -4683,10 +4753,14 @@ static int cgltf_parse_json_scene(cgltf_options* options, jsmntok_t const* token
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_scene->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_scene->extensions_count = 0;
-			out_scene->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_scene->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -4785,10 +4859,14 @@ static int cgltf_parse_json_animation_sampler(cgltf_options* options, jsmntok_t 
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_sampler->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_sampler->extensions_count = 0;
-			out_sampler->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_sampler->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -4885,10 +4963,14 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 					++i;
 
 					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+					if(out_channel->extensions)
+					{
+						return CGLTF_ERROR_JSON;
+					}
 
 					int extensions_size = tokens[i].size;
 					out_channel->extensions_count = 0;
-					out_channel->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+					out_channel->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 					++i;
 
@@ -4987,10 +5069,14 @@ static int cgltf_parse_json_animation(cgltf_options* options, jsmntok_t const* t
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_animation->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_animation->extensions_count = 0;
-			out_animation->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_animation->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -5075,10 +5161,14 @@ static int cgltf_parse_json_asset(cgltf_options* options, jsmntok_t const* token
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_asset->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_asset->extensions_count = 0;
-			out_asset->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_asset->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 
@@ -5251,10 +5341,14 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_data->data_extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			out_data->data_extensions_count = 0;
-			out_data->data_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_data->data_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
 			++i;
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -239,12 +239,20 @@ typedef struct cgltf_extras {
 	cgltf_size end_offset;
 } cgltf_extras;
 
+typedef struct cgltf_extension {
+	char* name;
+	cgltf_size start_offset;
+	cgltf_size end_offset;
+} cgltf_extension;
+
 typedef struct cgltf_buffer
 {
 	cgltf_size size;
 	char* uri;
 	void* data; /* loaded by cgltf_load_buffers */
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_buffer;
 
 typedef struct cgltf_buffer_view
@@ -255,6 +263,8 @@ typedef struct cgltf_buffer_view
 	cgltf_size stride; /* 0 == automatically determined by accessor */
 	cgltf_buffer_view_type type;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_buffer_view;
 
 typedef struct cgltf_accessor_sparse
@@ -268,6 +278,12 @@ typedef struct cgltf_accessor_sparse
 	cgltf_extras extras;
 	cgltf_extras indices_extras;
 	cgltf_extras values_extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
+	cgltf_size indices_extensions_count;
+	cgltf_extension* indices_extensions;
+	cgltf_size values_extensions_count;
+	cgltf_extension* values_extensions;
 } cgltf_accessor_sparse;
 
 typedef struct cgltf_accessor
@@ -286,6 +302,8 @@ typedef struct cgltf_accessor
 	cgltf_bool is_sparse;
 	cgltf_accessor_sparse sparse;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_accessor;
 
 typedef struct cgltf_attribute
@@ -303,6 +321,8 @@ typedef struct cgltf_image
 	cgltf_buffer_view* buffer_view;
 	char* mime_type;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_image;
 
 typedef struct cgltf_sampler
@@ -312,6 +332,8 @@ typedef struct cgltf_sampler
 	cgltf_int wrap_s;
 	cgltf_int wrap_t;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_sampler;
 
 typedef struct cgltf_texture
@@ -320,6 +342,8 @@ typedef struct cgltf_texture
 	cgltf_image* image;
 	cgltf_sampler* sampler;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_texture;
 
 typedef struct cgltf_texture_transform
@@ -338,6 +362,8 @@ typedef struct cgltf_texture_view
 	cgltf_bool has_transform;
 	cgltf_texture_transform transform;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_texture_view;
 
 typedef struct cgltf_pbr_metallic_roughness
@@ -390,6 +416,8 @@ typedef struct cgltf_material
 	cgltf_bool double_sided;
 	cgltf_bool unlit;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_material;
 
 typedef struct cgltf_morph_target {
@@ -414,6 +442,8 @@ typedef struct cgltf_primitive {
 	cgltf_extras extras;
 	cgltf_bool has_draco_mesh_compression;
 	cgltf_draco_mesh_compression draco_mesh_compression;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_primitive;
 
 typedef struct cgltf_mesh {
@@ -425,6 +455,8 @@ typedef struct cgltf_mesh {
 	char** target_names;
 	cgltf_size target_names_count;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_mesh;
 
 typedef struct cgltf_node cgltf_node;
@@ -436,6 +468,8 @@ typedef struct cgltf_skin {
 	cgltf_node* skeleton;
 	cgltf_accessor* inverse_bind_matrices;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_skin;
 
 typedef struct cgltf_camera_perspective {
@@ -462,6 +496,8 @@ typedef struct cgltf_camera {
 		cgltf_camera_orthographic orthographic;
 	} data;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_camera;
 
 typedef struct cgltf_light {
@@ -494,6 +530,8 @@ struct cgltf_node {
 	cgltf_float scale[3];
 	cgltf_float matrix[16];
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 };
 
 typedef struct cgltf_scene {
@@ -501,6 +539,8 @@ typedef struct cgltf_scene {
 	cgltf_node** nodes;
 	cgltf_size nodes_count;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_scene;
 
 typedef struct cgltf_animation_sampler {
@@ -508,6 +548,8 @@ typedef struct cgltf_animation_sampler {
 	cgltf_accessor* output;
 	cgltf_interpolation_type interpolation;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_animation_sampler;
 
 typedef struct cgltf_animation_channel {
@@ -515,6 +557,8 @@ typedef struct cgltf_animation_channel {
 	cgltf_node* target_node;
 	cgltf_animation_path_type target_path;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_animation_channel;
 
 typedef struct cgltf_animation {
@@ -524,6 +568,8 @@ typedef struct cgltf_animation {
 	cgltf_animation_channel* channels;
 	cgltf_size channels_count;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_animation;
 
 typedef struct cgltf_asset {
@@ -532,6 +578,8 @@ typedef struct cgltf_asset {
 	char* version;
 	char* min_version;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_asset;
 
 typedef struct cgltf_data
@@ -586,6 +634,9 @@ typedef struct cgltf_data
 	cgltf_size animations_count;
 
 	cgltf_extras extras;
+
+	cgltf_size data_extensions_count;
+	cgltf_extension* data_extensions;
 
 	char** extensions_used;
 	cgltf_size extensions_used_count;
@@ -1436,8 +1487,49 @@ void cgltf_free(cgltf_data* data)
 	data->memory.free(data->memory.user_data, data->asset.generator);
 	data->memory.free(data->memory.user_data, data->asset.version);
 	data->memory.free(data->memory.user_data, data->asset.min_version);
+	for (cgltf_size i = 0; i < data->asset.extensions_count; ++i)
+	{
+		data->memory.free(data->memory.user_data, data->asset.extensions[i].name);
+	}
+	data->memory.free(data->memory.user_data, data->asset.extensions);
 
+	for (cgltf_size i = 0; i < data->accessors_count; ++i)
+	{
+		if(data->accessors[i].is_sparse)
+		{
+			for (cgltf_size j = 0; j < data->accessors[i].sparse.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->accessors[i].sparse.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->accessors[i].sparse.extensions);
+			for (cgltf_size j = 0; j < data->accessors[i].sparse.indices_extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->accessors[i].sparse.indices_extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->accessors[i].sparse.indices_extensions);
+			for (cgltf_size j = 0; j < data->accessors[i].sparse.values_extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->accessors[i].sparse.values_extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->accessors[i].sparse.values_extensions);
+		}
+
+		for (cgltf_size j = 0; j < data->accessors[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->accessors[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->accessors[i].extensions);
+	}
 	data->memory.free(data->memory.user_data, data->accessors);
+
+	for (cgltf_size i = 0; i < data->buffer_views_count; ++i)
+	{
+		for (cgltf_size j = 0; j < data->buffer_views[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->buffer_views[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->buffer_views[i].extensions);
+	}
 	data->memory.free(data->memory.user_data, data->buffer_views);
 
 	for (cgltf_size i = 0; i < data->buffers_count; ++i)
@@ -1446,8 +1538,13 @@ void cgltf_free(cgltf_data* data)
 		{
 			file_release(&data->memory, &data->file, data->buffers[i].data);
 		}
-
 		data->memory.free(data->memory.user_data, data->buffers[i].uri);
+
+		for (cgltf_size j = 0; j < data->buffers[j].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->buffers[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->buffers[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->buffers);
@@ -1486,6 +1583,12 @@ void cgltf_free(cgltf_data* data)
 
 				data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].draco_mesh_compression.attributes);
 			}
+
+			for (cgltf_size k = 0; k < data->meshes[i].primitives[j].extensions_count; ++k)
+			{
+				data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].extensions[k].name);
+			}
+			data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].extensions);
 		}
 
 		data->memory.free(data->memory.user_data, data->meshes[i].primitives);
@@ -1496,6 +1599,12 @@ void cgltf_free(cgltf_data* data)
 			data->memory.free(data->memory.user_data, data->meshes[i].target_names[j]);
 		}
 
+		for (cgltf_size j = 0; j < data->meshes[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->meshes[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->meshes[i].extensions);
+
 		data->memory.free(data->memory.user_data, data->meshes[i].target_names);
 	}
 
@@ -1504,6 +1613,57 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->materials_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->materials[i].name);
+
+		if(data->materials[i].has_pbr_metallic_roughness)
+		{
+			for (cgltf_size j = 0; j < data->materials[i].pbr_metallic_roughness.base_color_texture.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions);
+			for (cgltf_size j = 0; j < data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions);
+		}
+		if(data->materials[i].has_pbr_specular_glossiness)
+		{
+			for (cgltf_size j = 0; j < data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions);
+			for (cgltf_size j = 0; j < data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions);
+		}
+		if(data->materials[i].has_clearcoat)
+		{
+			for (cgltf_size j = 0; j < data->materials[i].clearcoat.clearcoat_texture.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_texture.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_texture.extensions);
+			for (cgltf_size j = 0; j < data->materials[i].clearcoat.clearcoat_roughness_texture.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions);
+			for (cgltf_size j = 0; j < data->materials[i].clearcoat.clearcoat_normal_texture.extensions_count; ++j)
+			{
+				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions[j].name);
+			}
+			data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions);
+		}
+
+		for (cgltf_size j = 0; j < data->materials[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->materials[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->materials[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->materials);
@@ -1513,6 +1673,12 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->images[i].name);
 		data->memory.free(data->memory.user_data, data->images[i].uri);
 		data->memory.free(data->memory.user_data, data->images[i].mime_type);
+
+		for (cgltf_size j = 0; j < data->images[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->images[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->images[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->images);
@@ -1520,9 +1686,23 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->textures_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->textures[i].name);
+		for (cgltf_size j = 0; j < data->textures[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->textures[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->textures[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->textures);
+
+	for (cgltf_size i = 0; i < data->samplers_count; ++i)
+	{
+		for (cgltf_size j = 0; j < data->samplers[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->samplers[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->samplers[i].extensions);
+	}
 
 	data->memory.free(data->memory.user_data, data->samplers);
 
@@ -1530,6 +1710,12 @@ void cgltf_free(cgltf_data* data)
 	{
 		data->memory.free(data->memory.user_data, data->skins[i].name);
 		data->memory.free(data->memory.user_data, data->skins[i].joints);
+
+		for (cgltf_size j = 0; j < data->skins[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->skins[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->skins[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->skins);
@@ -1537,6 +1723,11 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->cameras_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->cameras[i].name);
+		for (cgltf_size j = 0; j < data->cameras[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->cameras[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->cameras[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->cameras);
@@ -1553,6 +1744,11 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->nodes[i].name);
 		data->memory.free(data->memory.user_data, data->nodes[i].children);
 		data->memory.free(data->memory.user_data, data->nodes[i].weights);
+		for (cgltf_size j = 0; j < data->nodes[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->nodes[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->nodes[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->nodes);
@@ -1561,6 +1757,12 @@ void cgltf_free(cgltf_data* data)
 	{
 		data->memory.free(data->memory.user_data, data->scenes[i].name);
 		data->memory.free(data->memory.user_data, data->scenes[i].nodes);
+
+		for (cgltf_size j = 0; j < data->scenes[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->scenes[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->scenes[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->scenes);
@@ -1568,11 +1770,40 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->animations_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->animations[i].name);
+		for (cgltf_size j = 0; j <  data->animations[i].samplers_count; ++j)
+		{
+			for (cgltf_size k = 0; k < data->animations[i].samplers[j].extensions_count; ++k)
+			{
+				data->memory.free(data->memory.user_data, data->animations[i].samplers[j].extensions[k].name);
+			}
+			data->memory.free(data->memory.user_data, data->animations[i].samplers[j].extensions);
+		}
 		data->memory.free(data->memory.user_data, data->animations[i].samplers);
+
+		for (cgltf_size j = 0; j <  data->animations[i].channels_count; ++j)
+		{
+			for (cgltf_size k = 0; k < data->animations[i].channels[j].extensions_count; ++k)
+			{
+				data->memory.free(data->memory.user_data, data->animations[i].channels[j].extensions[k].name);
+			}
+			data->memory.free(data->memory.user_data, data->animations[i].channels[j].extensions);
+		}
 		data->memory.free(data->memory.user_data, data->animations[i].channels);
+
+		for (cgltf_size j = 0; j < data->animations[i].extensions_count; ++j)
+		{
+			data->memory.free(data->memory.user_data, data->animations[i].extensions[j].name);
+		}
+		data->memory.free(data->memory.user_data, data->animations[i].extensions);
 	}
 
 	data->memory.free(data->memory.user_data, data->animations);
+
+	for (cgltf_size i = 0; i < data->data_extensions_count; ++i)
+	{
+		data->memory.free(data->memory.user_data, data->data_extensions[i].name);
+	}
+	data->memory.free(data->memory.user_data, data->data_extensions);
 
 	for (cgltf_size i = 0; i < data->extensions_used_count; ++i)
 	{
@@ -2198,6 +2429,22 @@ static int cgltf_parse_json_extras(jsmntok_t const* tokens, int i, const uint8_t
 	return i;
 }
 
+static int cgltf_parse_json_unprocessed_extension(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_extension* out_extension)
+{
+	cgltf_size name_length = tokens[i].end - tokens[i].start;
+	out_extension->name = (char*)options->memory.alloc(options->memory.user_data, name_length + 1);
+	strncpy(out_extension->name, (const char*)json_chunk + tokens[i].start, name_length);
+	out_extension->name[name_length] = 0;
+	i++;
+
+	out_extension->start_offset = tokens[i].start;
+	out_extension->end_offset = tokens[i].end;
+
+	i = cgltf_skip_json(tokens, i);
+
+	return i;
+}
+
 static int cgltf_parse_json_draco_mesh_compression(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_draco_mesh_compression* out_draco_mesh_compression)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -2289,8 +2536,10 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			++i;
+			int unprocessed_extensions = 0;
+			out_prim->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
+			++i;
 			for (int k = 0; k < extensions_size; ++k)
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
@@ -2302,7 +2551,7 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_prim->extensions[unprocessed_extensions++]));
 				}
 
 				if (i < 0)
@@ -2310,6 +2559,7 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 					return i;
 				}
 			}
+			out_prim->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -2403,6 +2653,31 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 				i = cgltf_skip_json(tokens, i);
 			}
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_mesh->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_mesh->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_mesh->extensions_count = unprocessed_extensions;
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -2459,7 +2734,7 @@ static cgltf_component_type cgltf_json_to_component_type(jsmntok_t const* tok, c
 	}
 }
 
-static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor_sparse* out_sparse)
+static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor_sparse* out_sparse)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2510,6 +2785,31 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 				{
 					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sparse->indices_extras);
 				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+				{
+					++i;
+
+					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+					int extensions_size = tokens[i].size;
+					int unprocessed_extensions = 0;
+					out_sparse->indices_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+					++i;
+
+					for (int k = 0; k < extensions_size; ++k)
+					{
+						CGLTF_CHECK_KEY(tokens[i]);
+
+						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->indices_extensions[unprocessed_extensions++]));
+
+						if (i < 0)
+						{
+							return i;
+						}
+					}
+					out_sparse->indices_extensions_count = unprocessed_extensions;
+				}
 				else
 				{
 					i = cgltf_skip_json(tokens, i+1);
@@ -2549,6 +2849,31 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 				{
 					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sparse->values_extras);
 				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+				{
+					++i;
+
+					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+					int extensions_size = tokens[i].size;
+					int unprocessed_extensions = 0;
+					out_sparse->values_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+					++i;
+
+					for (int k = 0; k < extensions_size; ++k)
+					{
+						CGLTF_CHECK_KEY(tokens[i]);
+
+						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->values_extensions[unprocessed_extensions++]));
+
+						if (i < 0)
+						{
+							return i;
+						}
+					}
+					out_sparse->values_extensions_count = unprocessed_extensions;
+				}
 				else
 				{
 					i = cgltf_skip_json(tokens, i+1);
@@ -2564,6 +2889,31 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sparse->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_sparse->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_sparse->extensions_count = unprocessed_extensions;
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -2578,7 +2928,7 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 	return i;
 }
 
-static int cgltf_parse_json_accessor(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor* out_accessor)
+static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor* out_accessor)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2673,11 +3023,36 @@ static int cgltf_parse_json_accessor(jsmntok_t const* tokens, int i, const uint8
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "sparse") == 0)
 		{
 			out_accessor->is_sparse = 1;
-			i = cgltf_parse_json_accessor_sparse(tokens, i + 1, json_chunk, &out_accessor->sparse);
+			i = cgltf_parse_json_accessor_sparse(options, tokens, i + 1, json_chunk, &out_accessor->sparse);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_accessor->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_accessor->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_accessor->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_accessor->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -2738,7 +3113,7 @@ static int cgltf_parse_json_texture_transform(jsmntok_t const* tokens, int i, co
 	return i;
 }
 
-static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_texture_view* out_texture_view)
+static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_texture_view* out_texture_view)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2787,6 +3162,9 @@ static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const u
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_texture_view->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
 			++i;
 
 			for (int k = 0; k < extensions_size; ++k)
@@ -2800,7 +3178,7 @@ static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const u
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture_view->extensions[unprocessed_extensions++]));
 				}
 
 				if (i < 0)
@@ -2808,6 +3186,7 @@ static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const u
 					return i;
 				}
 			}
+			out_texture_view->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -2823,7 +3202,7 @@ static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const u
 	return i;
 }
 
-static int cgltf_parse_json_pbr_metallic_roughness(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_metallic_roughness* out_pbr)
+static int cgltf_parse_json_pbr_metallic_roughness(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_metallic_roughness* out_pbr)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2854,12 +3233,12 @@ static int cgltf_parse_json_pbr_metallic_roughness(jsmntok_t const* tokens, int 
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "baseColorTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_pbr->base_color_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "metallicRoughnessTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_pbr->metallic_roughness_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
@@ -2880,7 +3259,7 @@ static int cgltf_parse_json_pbr_metallic_roughness(jsmntok_t const* tokens, int 
 	return i;
 }
 
-static int cgltf_parse_json_pbr_specular_glossiness(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_specular_glossiness* out_pbr)
+static int cgltf_parse_json_pbr_specular_glossiness(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_specular_glossiness* out_pbr)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 	int size = tokens[i].size;
@@ -2906,11 +3285,11 @@ static int cgltf_parse_json_pbr_specular_glossiness(jsmntok_t const* tokens, int
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "diffuseTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_pbr->diffuse_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_pbr->diffuse_texture);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "specularGlossinessTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_pbr->specular_glossiness_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_pbr->specular_glossiness_texture);
 		}
 		else
 		{
@@ -2926,7 +3305,7 @@ static int cgltf_parse_json_pbr_specular_glossiness(jsmntok_t const* tokens, int
 	return i;
 }
 
-static int cgltf_parse_json_clearcoat(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_clearcoat* out_clearcoat)
+static int cgltf_parse_json_clearcoat(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_clearcoat* out_clearcoat)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 	int size = tokens[i].size;
@@ -2950,15 +3329,15 @@ static int cgltf_parse_json_clearcoat(jsmntok_t const* tokens, int i, const uint
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "clearcoatTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_texture);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "clearcoatRoughnessTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_roughness_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_roughness_texture);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "clearcoatNormalTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_normal_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_normal_texture);
 		}
 		else
 		{
@@ -3006,6 +3385,31 @@ static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_image->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_image->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_image->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_image->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3068,6 +3472,31 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sampler->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_sampler->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_sampler->extensions_count = unprocessed_extensions;
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i + 1);
@@ -3114,6 +3543,30 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_texture->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			++i;
+
+			out_texture->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+			out_texture->extensions_count = extensions_size;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture->extensions[k]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i + 1);
@@ -3156,7 +3609,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "pbrMetallicRoughness") == 0)
 		{
 			out_material->has_pbr_metallic_roughness = 1;
-			i = cgltf_parse_json_pbr_metallic_roughness(tokens, i + 1, json_chunk, &out_material->pbr_metallic_roughness);
+			i = cgltf_parse_json_pbr_metallic_roughness(options, tokens, i + 1, json_chunk, &out_material->pbr_metallic_roughness);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "emissiveFactor") == 0)
 		{
@@ -3164,17 +3617,17 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "normalTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_material->normal_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "occlusionTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_material->occlusion_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "emissiveTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_material->emissive_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "alphaMode") == 0)
@@ -3219,6 +3672,9 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 
 			int extensions_size = tokens[i].size;
 			++i;
+			out_material->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			int unhandled_extensions = 0;
 
 			for (int k = 0; k < extensions_size; ++k)
 			{
@@ -3227,7 +3683,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_pbrSpecularGlossiness") == 0)
 				{
 					out_material->has_pbr_specular_glossiness = 1;
-					i = cgltf_parse_json_pbr_specular_glossiness(tokens, i + 1, json_chunk, &out_material->pbr_specular_glossiness);
+					i = cgltf_parse_json_pbr_specular_glossiness(options, tokens, i + 1, json_chunk, &out_material->pbr_specular_glossiness);
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_unlit") == 0)
 				{
@@ -3237,11 +3693,11 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_clearcoat") == 0)
 				{
 					out_material->has_clearcoat = 1;
-					i = cgltf_parse_json_clearcoat(tokens, i + 1, json_chunk, &out_material->clearcoat);
+					i = cgltf_parse_json_clearcoat(options, tokens, i + 1, json_chunk, &out_material->clearcoat);
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_material->extensions[unhandled_extensions++]));
 				}
 
 				if (i < 0)
@@ -3249,6 +3705,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 					return i;
 				}
 			}
+			out_material->extensions_count = unhandled_extensions;
 		}
 		else
 		{
@@ -3274,7 +3731,7 @@ static int cgltf_parse_json_accessors(cgltf_options* options, jsmntok_t const* t
 
 	for (cgltf_size j = 0; j < out_data->accessors_count; ++j)
 	{
-		i = cgltf_parse_json_accessor(tokens, i, json_chunk, &out_data->accessors[j]);
+		i = cgltf_parse_json_accessor(options, tokens, i, json_chunk, &out_data->accessors[j]);
 		if (i < 0)
 		{
 			return i;
@@ -3359,7 +3816,7 @@ static int cgltf_parse_json_samplers(cgltf_options* options, jsmntok_t const* to
 	return i;
 }
 
-static int cgltf_parse_json_buffer_view(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_buffer_view* out_buffer_view)
+static int cgltf_parse_json_buffer_view(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_buffer_view* out_buffer_view)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -3420,6 +3877,31 @@ static int cgltf_parse_json_buffer_view(jsmntok_t const* tokens, int i, const ui
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_buffer_view->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_buffer_view->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer_view->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_buffer_view->extensions_count = unprocessed_extensions;
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -3444,7 +3926,7 @@ static int cgltf_parse_json_buffer_views(cgltf_options* options, jsmntok_t const
 
 	for (cgltf_size j = 0; j < out_data->buffer_views_count; ++j)
 	{
-		i = cgltf_parse_json_buffer_view(tokens, i, json_chunk, &out_data->buffer_views[j]);
+		i = cgltf_parse_json_buffer_view(options, tokens, i, json_chunk, &out_data->buffer_views[j]);
 		if (i < 0)
 		{
 			return i;
@@ -3478,6 +3960,31 @@ static int cgltf_parse_json_buffer(cgltf_options* options, jsmntok_t const* toke
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_buffer->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_buffer->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_buffer->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3558,6 +4065,31 @@ static int cgltf_parse_json_skin(cgltf_options* options, jsmntok_t const* tokens
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_skin->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_skin->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_skin->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_skin->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3731,6 +4263,31 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_camera->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_camera->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_camera->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_camera->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3982,6 +4539,9 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_node->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
 			++i;
 
 			for (int k = 0; k < extensions_size; ++k)
@@ -4021,7 +4581,7 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_node->extensions[unprocessed_extensions++]));
 				}
 
 				if (i < 0)
@@ -4029,6 +4589,7 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 					return i;
 				}
 			}
+			out_node->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4095,6 +4656,31 @@ static int cgltf_parse_json_scene(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_scene->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_scene->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_scene->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_scene->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4174,6 +4760,31 @@ static int cgltf_parse_json_animation_sampler(cgltf_options* options, jsmntok_t 
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sampler->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_sampler->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_sampler->extensions_count = unprocessed_extensions;
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -4249,6 +4860,31 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 				{
 					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_channel->extras);
+				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+				{
+					++i;
+
+					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+					int extensions_size = tokens[i].size;
+					int unprocessed_extensions = 0;
+					out_channel->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+					++i;
+
+					for (int k = 0; k < extensions_size; ++k)
+					{
+						CGLTF_CHECK_KEY(tokens[i]);
+
+						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_channel->extensions[unprocessed_extensions++]));
+
+						if (i < 0)
+						{
+							return i;
+						}
+					}
+					out_channel->extensions_count = unprocessed_extensions;
 				}
 				else
 				{
@@ -4328,6 +4964,31 @@ static int cgltf_parse_json_animation(cgltf_options* options, jsmntok_t const* t
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_animation->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_animation->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_animation->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_animation->extensions_count = unprocessed_extensions;
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -4391,6 +5052,31 @@ static int cgltf_parse_json_asset(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_asset->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+
+			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_asset->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
+			++i;
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_asset->extensions[unprocessed_extensions++]));
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
+			out_asset->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4551,6 +5237,9 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
+			int unprocessed_extensions = 0;
+			out_data->data_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
+
 			++i;
 
 			for (int k = 0; k < extensions_size; ++k)
@@ -4587,7 +5276,7 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i + 1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_data->data_extensions[unprocessed_extensions++]));
 				}
 
 				if (i < 0)
@@ -4595,6 +5284,8 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 					return i;
 				}
 			}
+			out_data->data_extensions_count = unprocessed_extensions;
+
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensionsUsed") == 0)
 		{

--- a/cgltf.h
+++ b/cgltf.h
@@ -1540,7 +1540,7 @@ void cgltf_free(cgltf_data* data)
 		}
 		data->memory.free(data->memory.user_data, data->buffers[i].uri);
 
-		for (cgltf_size j = 0; j < data->buffers[j].extensions_count; ++j)
+		for (cgltf_size j = 0; j < data->buffers[i].extensions_count; ++j)
 		{
 			data->memory.free(data->memory.user_data, data->buffers[i].extensions[j].name);
 		}
@@ -2536,7 +2536,7 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_prim->extensions_count = 0;
 			out_prim->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -2551,7 +2551,7 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 				}
 				else
 				{
-					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_prim->extensions[unprocessed_extensions++]));
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_prim->extensions[out_prim->extensions_count++]));
 				}
 
 				if (i < 0)
@@ -2559,7 +2559,6 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 					return i;
 				}
 			}
-			out_prim->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -2660,7 +2659,7 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_mesh->extensions_count = 0;
 			out_mesh->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -2669,14 +2668,13 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_mesh->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_mesh->extensions[out_mesh->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_mesh->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -2792,7 +2790,7 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 					int extensions_size = tokens[i].size;
-					int unprocessed_extensions = 0;
+					out_sparse->indices_extensions_count = 0;
 					out_sparse->indices_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 					++i;
@@ -2801,14 +2799,13 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					{
 						CGLTF_CHECK_KEY(tokens[i]);
 
-						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->indices_extensions[unprocessed_extensions++]));
+						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->indices_extensions[out_sparse->indices_extensions_count++]));
 
 						if (i < 0)
 						{
 							return i;
 						}
 					}
-					out_sparse->indices_extensions_count = unprocessed_extensions;
 				}
 				else
 				{
@@ -2856,7 +2853,7 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 					int extensions_size = tokens[i].size;
-					int unprocessed_extensions = 0;
+					out_sparse->values_extensions_count = 0;
 					out_sparse->values_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 					++i;
@@ -2865,14 +2862,13 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					{
 						CGLTF_CHECK_KEY(tokens[i]);
 
-						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->values_extensions[unprocessed_extensions++]));
+						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->values_extensions[out_sparse->values_extensions_count++]));
 
 						if (i < 0)
 						{
 							return i;
 						}
 					}
-					out_sparse->values_extensions_count = unprocessed_extensions;
 				}
 				else
 				{
@@ -2896,7 +2892,7 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_sparse->extensions_count = 0;
 			out_sparse->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -2905,14 +2901,13 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->extensions[out_sparse->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_sparse->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3036,7 +3031,7 @@ static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* to
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_accessor->extensions_count = 0;
 			out_accessor->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -3045,14 +3040,13 @@ static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* to
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_accessor->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_accessor->extensions[out_accessor->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_accessor->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3162,7 +3156,7 @@ static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_texture_view->extensions_count = 0;
 			out_texture_view->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -3178,7 +3172,7 @@ static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const
 				}
 				else
 				{
-					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture_view->extensions[unprocessed_extensions++]));
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture_view->extensions[out_texture_view->extensions_count++]));
 				}
 
 				if (i < 0)
@@ -3186,7 +3180,6 @@ static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const
 					return i;
 				}
 			}
-			out_texture_view->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3393,7 +3386,7 @@ static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* token
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_image->extensions_count = 0;
 			out_image->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -3402,14 +3395,13 @@ static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* token
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_image->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_image->extensions[out_image->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_image->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3479,7 +3471,7 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_sampler->extensions_count = 0;
 			out_sampler->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -3488,14 +3480,13 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[out_sampler->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_sampler->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3550,16 +3541,16 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			++i;
-
+			out_texture->extensions_count = 0;
 			out_texture->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
-			out_texture->extensions_count = extensions_size;
+
+			++i;
 
 			for (int k = 0; k < extensions_size; ++k)
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture->extensions[k]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture->extensions[out_texture->extensions_count++]));
 
 				if (i < 0)
 				{
@@ -3702,6 +3693,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 
 				if (i < 0)
 				{
+					out_material->extensions_count = unhandled_extensions;
 					return i;
 				}
 			}
@@ -3884,7 +3876,7 @@ static int cgltf_parse_json_buffer_view(cgltf_options* options, jsmntok_t const*
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_buffer_view->extensions_count = 0;
 			out_buffer_view->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -3893,14 +3885,13 @@ static int cgltf_parse_json_buffer_view(cgltf_options* options, jsmntok_t const*
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer_view->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer_view->extensions[out_buffer_view->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_buffer_view->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -3968,7 +3959,7 @@ static int cgltf_parse_json_buffer(cgltf_options* options, jsmntok_t const* toke
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_buffer->extensions_count = 0;
 			out_buffer->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -3977,14 +3968,13 @@ static int cgltf_parse_json_buffer(cgltf_options* options, jsmntok_t const* toke
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer->extensions[out_buffer->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_buffer->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4073,7 +4063,7 @@ static int cgltf_parse_json_skin(cgltf_options* options, jsmntok_t const* tokens
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_skin->extensions_count = 0;
 			out_skin->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -4082,14 +4072,13 @@ static int cgltf_parse_json_skin(cgltf_options* options, jsmntok_t const* tokens
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_skin->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_skin->extensions[out_skin->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_skin->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4271,7 +4260,7 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_camera->extensions_count = 0;
 			out_camera->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -4280,14 +4269,13 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_camera->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_camera->extensions[out_camera->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_camera->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4539,7 +4527,7 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_node->extensions_count= 0;
 			out_node->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -4581,7 +4569,7 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else
 				{
-					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_node->extensions[unprocessed_extensions++]));
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_node->extensions[out_node->extensions_count++]));
 				}
 
 				if (i < 0)
@@ -4589,7 +4577,6 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 					return i;
 				}
 			}
-			out_node->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4664,7 +4651,7 @@ static int cgltf_parse_json_scene(cgltf_options* options, jsmntok_t const* token
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_scene->extensions_count = 0;
 			out_scene->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -4673,14 +4660,13 @@ static int cgltf_parse_json_scene(cgltf_options* options, jsmntok_t const* token
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_scene->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_scene->extensions[out_scene->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_scene->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4767,7 +4753,7 @@ static int cgltf_parse_json_animation_sampler(cgltf_options* options, jsmntok_t 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_sampler->extensions_count = 0;
 			out_sampler->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -4776,14 +4762,13 @@ static int cgltf_parse_json_animation_sampler(cgltf_options* options, jsmntok_t 
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[out_sampler->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_sampler->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -4868,7 +4853,7 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 					int extensions_size = tokens[i].size;
-					int unprocessed_extensions = 0;
+					out_channel->extensions_count = 0;
 					out_channel->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 					++i;
@@ -4877,14 +4862,13 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 					{
 						CGLTF_CHECK_KEY(tokens[i]);
 
-						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_channel->extensions[unprocessed_extensions++]));
+						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_channel->extensions[out_channel->extensions_count++]));
 
 						if (i < 0)
 						{
 							return i;
 						}
 					}
-					out_channel->extensions_count = unprocessed_extensions;
 				}
 				else
 				{
@@ -4971,7 +4955,7 @@ static int cgltf_parse_json_animation(cgltf_options* options, jsmntok_t const* t
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_animation->extensions_count = 0;
 			out_animation->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -4980,14 +4964,13 @@ static int cgltf_parse_json_animation(cgltf_options* options, jsmntok_t const* t
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_animation->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_animation->extensions[out_animation->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_animation->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -5060,7 +5043,7 @@ static int cgltf_parse_json_asset(cgltf_options* options, jsmntok_t const* token
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_asset->extensions_count = 0;
 			out_asset->extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -5069,14 +5052,13 @@ static int cgltf_parse_json_asset(cgltf_options* options, jsmntok_t const* token
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
 
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_asset->extensions[unprocessed_extensions++]));
+				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_asset->extensions[out_asset->extensions_count++]));
 
 				if (i < 0)
 				{
 					return i;
 				}
 			}
-			out_asset->extensions_count = unprocessed_extensions;
 		}
 		else
 		{
@@ -5237,7 +5219,7 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 			int extensions_size = tokens[i].size;
-			int unprocessed_extensions = 0;
+			out_data->data_extensions_count = 0;
 			out_data->data_extensions = (cgltf_extension*)options->memory.alloc(options->memory.user_data, extensions_size*sizeof(cgltf_extension));
 
 			++i;
@@ -5276,7 +5258,7 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else
 				{
-					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_data->data_extensions[unprocessed_extensions++]));
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_data->data_extensions[out_data->data_extensions_count++]));
 				}
 
 				if (i < 0)
@@ -5284,8 +5266,6 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 					return i;
 				}
 			}
-			out_data->data_extensions_count = unprocessed_extensions;
-
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensionsUsed") == 0)
 		{

--- a/cgltf.h
+++ b/cgltf.h
@@ -2356,6 +2356,38 @@ static int cgltf_parse_json_unprocessed_extension(cgltf_options* options, jsmnto
 	return i;
 }
 
+static int cgltf_parse_json_unprocessed_extensions(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_size* out_extensions_count, cgltf_extension** out_extensions)
+{
+	++i;
+
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	if(*out_extensions)
+	{
+		return CGLTF_ERROR_JSON;
+	}
+
+	int extensions_size = tokens[i].size;
+	*out_extensions_count = 0;
+	*out_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
+
+	++i;
+
+	for (int j = 0; j < extensions_size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		cgltf_size extension_index = (*out_extensions_count)++;
+		cgltf_extension* extension = &((*out_extensions)[extension_index]);
+		i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, extension);
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+	return i;
+}
+
 static int cgltf_parse_json_draco_mesh_compression(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_draco_mesh_compression* out_draco_mesh_compression)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -2814,30 +2846,10 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_sparse->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->extensions_count, &out_sparse->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_sparse->extensions_count = 0;
-			out_sparse->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->extensions[out_sparse->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -2957,30 +2969,10 @@ static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* to
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_accessor->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_accessor->extensions_count, &out_accessor->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_accessor->extensions_count = 0;
-			out_accessor->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_accessor->extensions[out_accessor->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -3320,30 +3312,10 @@ static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* token
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_image->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_image->extensions_count, &out_image->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_image->extensions_count = 0;
-			out_image->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_image->extensions[out_image->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -3409,30 +3381,10 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_sampler->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sampler->extensions_count, &out_sampler->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_sampler->extensions_count = 0;
-			out_sampler->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[out_sampler->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -3448,7 +3400,6 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 
 	return i;
 }
-
 
 static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_texture* out_texture)
 {
@@ -3483,30 +3434,10 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_texture->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_texture->extensions_count, &out_texture->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_texture->extensions_count = 0;
-			out_texture->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture->extensions[out_texture->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -3823,30 +3754,10 @@ static int cgltf_parse_json_buffer_view(cgltf_options* options, jsmntok_t const*
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_buffer_view->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_buffer_view->extensions_count, &out_buffer_view->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_buffer_view->extensions_count = 0;
-			out_buffer_view->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer_view->extensions[out_buffer_view->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -3910,30 +3821,10 @@ static int cgltf_parse_json_buffer(cgltf_options* options, jsmntok_t const* toke
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_buffer->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_buffer->extensions_count, &out_buffer->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_buffer->extensions_count = 0;
-			out_buffer->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_buffer->extensions[out_buffer->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -4018,30 +3909,10 @@ static int cgltf_parse_json_skin(cgltf_options* options, jsmntok_t const* tokens
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_skin->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_skin->extensions_count, &out_skin->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_skin->extensions_count = 0;
-			out_skin->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_skin->extensions[out_skin->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -4219,30 +4090,10 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_camera->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_camera->extensions_count, &out_camera->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_camera->extensions_count = 0;
-			out_camera->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_camera->extensions[out_camera->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -4618,30 +4469,10 @@ static int cgltf_parse_json_scene(cgltf_options* options, jsmntok_t const* token
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_scene->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_scene->extensions_count, &out_scene->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_scene->extensions_count = 0;
-			out_scene->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_scene->extensions[out_scene->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -4724,30 +4555,10 @@ static int cgltf_parse_json_animation_sampler(cgltf_options* options, jsmntok_t 
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_sampler->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sampler->extensions_count, &out_sampler->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_sampler->extensions_count = 0;
-			out_sampler->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sampler->extensions[out_sampler->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -4934,30 +4745,10 @@ static int cgltf_parse_json_animation(cgltf_options* options, jsmntok_t const* t
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_animation->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_animation->extensions_count, &out_animation->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_animation->extensions_count = 0;
-			out_animation->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_animation->extensions[out_animation->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else
@@ -5026,30 +4817,10 @@ static int cgltf_parse_json_asset(cgltf_options* options, jsmntok_t const* token
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_asset->extensions)
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_asset->extensions_count, &out_asset->extensions);
+			if (i < 0)
 			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_asset->extensions_count = 0;
-			out_asset->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_asset->extensions[out_asset->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
+				return i;
 			}
 		}
 		else

--- a/cgltf.h
+++ b/cgltf.h
@@ -2601,31 +2601,7 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			++i;
-
-			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_mesh->extensions)
-			{
-				return CGLTF_ERROR_JSON;
-			}
-
-			int extensions_size = tokens[i].size;
-			out_mesh->extensions_count = 0;
-			out_mesh->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			++i;
-
-			for (int k = 0; k < extensions_size; ++k)
-			{
-				CGLTF_CHECK_KEY(tokens[i]);
-
-				i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_mesh->extensions[out_mesh->extensions_count++]));
-
-				if (i < 0)
-				{
-					return i;
-				}
-			}
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_mesh->extensions_count, &out_mesh->extensions);
 		}
 		else
 		{
@@ -2737,10 +2713,6 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 				{
 					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->indices_extensions_count, &out_sparse->indices_extensions);
-					if (i < 0)
-					{
-						return i;
-					}
 				}
 				else
 				{
@@ -2784,10 +2756,6 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 				{
 					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->values_extensions_count, &out_sparse->values_extensions);
-					if (i < 0)
-					{
-						return i;
-					}
 				}
 				else
 				{
@@ -2807,10 +2775,6 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->extensions_count, &out_sparse->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -2930,10 +2894,6 @@ static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* to
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_accessor->extensions_count, &out_accessor->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -3273,10 +3233,6 @@ static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_image->extensions_count, &out_image->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -3342,10 +3298,6 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sampler->extensions_count, &out_sampler->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -3395,10 +3347,6 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_texture->extensions_count, &out_texture->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -3715,10 +3663,6 @@ static int cgltf_parse_json_buffer_view(cgltf_options* options, jsmntok_t const*
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_buffer_view->extensions_count, &out_buffer_view->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -3782,10 +3726,6 @@ static int cgltf_parse_json_buffer(cgltf_options* options, jsmntok_t const* toke
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_buffer->extensions_count, &out_buffer->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -3870,10 +3810,6 @@ static int cgltf_parse_json_skin(cgltf_options* options, jsmntok_t const* tokens
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_skin->extensions_count, &out_skin->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -4051,10 +3987,6 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_camera->extensions_count, &out_camera->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -4430,10 +4362,6 @@ static int cgltf_parse_json_scene(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_scene->extensions_count, &out_scene->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -4516,10 +4444,6 @@ static int cgltf_parse_json_animation_sampler(cgltf_options* options, jsmntok_t 
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sampler->extensions_count, &out_sampler->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -4600,10 +4524,6 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 				{
 					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_channel->extensions_count, &out_channel->extensions);
-					if (i < 0)
-					{
-						return i;
-					}
 				}
 				else
 				{
@@ -4686,10 +4606,6 @@ static int cgltf_parse_json_animation(cgltf_options* options, jsmntok_t const* t
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_animation->extensions_count, &out_animation->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{
@@ -4758,10 +4674,6 @@ static int cgltf_parse_json_asset(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_asset->extensions_count, &out_asset->extensions);
-			if (i < 0)
-			{
-				return i;
-			}
 		}
 		else
 		{

--- a/cgltf.h
+++ b/cgltf.h
@@ -1473,6 +1473,16 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 	return cgltf_result_success;
 }
 
+void cgltf_free_extensions(cgltf_data* data, cgltf_extension* extensions, cgltf_size extensions_count)
+{
+	for (cgltf_size i = 0; i < extensions_count; ++i)
+	{
+		data->memory.free(data->memory.user_data, extensions[i].name);
+		data->memory.free(data->memory.user_data, extensions[i].data);
+	}
+	data->memory.free(data->memory.user_data, extensions);
+}
+
 void cgltf_free(cgltf_data* data)
 {
 	if (!data)
@@ -1486,54 +1496,24 @@ void cgltf_free(cgltf_data* data)
 	data->memory.free(data->memory.user_data, data->asset.generator);
 	data->memory.free(data->memory.user_data, data->asset.version);
 	data->memory.free(data->memory.user_data, data->asset.min_version);
-	for (cgltf_size i = 0; i < data->asset.extensions_count; ++i)
-	{
-		data->memory.free(data->memory.user_data, data->asset.extensions[i].name);
-		data->memory.free(data->memory.user_data, data->asset.extensions[i].data);
-	}
-	data->memory.free(data->memory.user_data, data->asset.extensions);
+
+	cgltf_free_extensions(data, data->asset.extensions, data->asset.extensions_count);
 
 	for (cgltf_size i = 0; i < data->accessors_count; ++i)
 	{
 		if(data->accessors[i].is_sparse)
 		{
-			for (cgltf_size j = 0; j < data->accessors[i].sparse.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->accessors[i].sparse.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->accessors[i].sparse.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->accessors[i].sparse.extensions);
-			for (cgltf_size j = 0; j < data->accessors[i].sparse.indices_extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->accessors[i].sparse.indices_extensions[j].name);
-				data->memory.free(data->memory.user_data, data->accessors[i].sparse.indices_extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->accessors[i].sparse.indices_extensions);
-			for (cgltf_size j = 0; j < data->accessors[i].sparse.values_extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->accessors[i].sparse.values_extensions[j].name);
-				data->memory.free(data->memory.user_data, data->accessors[i].sparse.values_extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->accessors[i].sparse.values_extensions);
+			cgltf_free_extensions(data, data->accessors[i].sparse.extensions, data->accessors[i].sparse.extensions_count);
+			cgltf_free_extensions(data, data->accessors[i].sparse.indices_extensions, data->accessors[i].sparse.indices_extensions_count);
+			cgltf_free_extensions(data, data->accessors[i].sparse.values_extensions, data->accessors[i].sparse.values_extensions_count);
 		}
-
-		for (cgltf_size j = 0; j < data->accessors[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->accessors[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->accessors[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->accessors[i].extensions);
+		cgltf_free_extensions(data, data->accessors[i].extensions, data->accessors[i].extensions_count);
 	}
 	data->memory.free(data->memory.user_data, data->accessors);
 
 	for (cgltf_size i = 0; i < data->buffer_views_count; ++i)
 	{
-		for (cgltf_size j = 0; j < data->buffer_views[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->buffer_views[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->buffer_views[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->buffer_views[i].extensions);
+		cgltf_free_extensions(data, data->buffer_views[i].extensions, data->buffer_views[i].extensions_count);
 	}
 	data->memory.free(data->memory.user_data, data->buffer_views);
 
@@ -1545,12 +1525,7 @@ void cgltf_free(cgltf_data* data)
 		}
 		data->memory.free(data->memory.user_data, data->buffers[i].uri);
 
-		for (cgltf_size j = 0; j < data->buffers[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->buffers[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->buffers[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->buffers[i].extensions);
+		cgltf_free_extensions(data, data->buffers[i].extensions, data->buffers[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->buffers);
@@ -1590,12 +1565,7 @@ void cgltf_free(cgltf_data* data)
 				data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].draco_mesh_compression.attributes);
 			}
 
-			for (cgltf_size k = 0; k < data->meshes[i].primitives[j].extensions_count; ++k)
-			{
-				data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].extensions[k].name);
-				data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].extensions[k].data);
-			}
-			data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].extensions);
+			cgltf_free_extensions(data, data->meshes[i].primitives[j].extensions, data->meshes[i].primitives[j].extensions_count);
 		}
 
 		data->memory.free(data->memory.user_data, data->meshes[i].primitives);
@@ -1606,12 +1576,7 @@ void cgltf_free(cgltf_data* data)
 			data->memory.free(data->memory.user_data, data->meshes[i].target_names[j]);
 		}
 
-		for (cgltf_size j = 0; j < data->meshes[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->meshes[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->meshes[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->meshes[i].extensions);
+		cgltf_free_extensions(data, data->meshes[i].extensions, data->meshes[i].extensions_count);
 
 		data->memory.free(data->memory.user_data, data->meshes[i].target_names);
 	}
@@ -1624,81 +1589,26 @@ void cgltf_free(cgltf_data* data)
 
 		if(data->materials[i].has_pbr_metallic_roughness)
 		{
-			for (cgltf_size j = 0; j < data->materials[i].pbr_metallic_roughness.base_color_texture.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions);
-			for (cgltf_size j = 0; j < data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions);
+			cgltf_free_extensions(data, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions_count);
 		}
 		if(data->materials[i].has_pbr_specular_glossiness)
 		{
-			for (cgltf_size j = 0; j < data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions);
-			for (cgltf_size j = 0; j < data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions);
+			cgltf_free_extensions(data, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions_count);
 		}
 		if(data->materials[i].has_clearcoat)
 		{
-			for (cgltf_size j = 0; j < data->materials[i].clearcoat.clearcoat_texture.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_texture.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_texture.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_texture.extensions);
-			for (cgltf_size j = 0; j < data->materials[i].clearcoat.clearcoat_roughness_texture.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions);
-			for (cgltf_size j = 0; j < data->materials[i].clearcoat.clearcoat_normal_texture.extensions_count; ++j)
-			{
-				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions[j].name);
-				data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions[j].data);
-			}
-			data->memory.free(data->memory.user_data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions);
+			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_texture.extensions, data->materials[i].clearcoat.clearcoat_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions, data->materials[i].clearcoat.clearcoat_normal_texture.extensions_count);
 		}
 
-		for (cgltf_size j = 0; j < data->materials[i].normal_texture.extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->materials[i].normal_texture.extensions[j].name);
-			data->memory.free(data->memory.user_data, data->materials[i].normal_texture.extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->materials[i].normal_texture.extensions);
-		for (cgltf_size j = 0; j < data->materials[i].occlusion_texture.extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->materials[i].occlusion_texture.extensions[j].name);
-			data->memory.free(data->memory.user_data, data->materials[i].occlusion_texture.extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->materials[i].occlusion_texture.extensions);
-		for (cgltf_size j = 0; j < data->materials[i].emissive_texture.extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->materials[i].emissive_texture.extensions[j].name);
-			data->memory.free(data->memory.user_data, data->materials[i].emissive_texture.extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->materials[i].emissive_texture.extensions);
+		cgltf_free_extensions(data, data->materials[i].normal_texture.extensions, data->materials[i].normal_texture.extensions_count);
+		cgltf_free_extensions(data, data->materials[i].occlusion_texture.extensions, data->materials[i].occlusion_texture.extensions_count);
+		cgltf_free_extensions(data, data->materials[i].emissive_texture.extensions, data->materials[i].emissive_texture.extensions_count);
 
-		for (cgltf_size j = 0; j < data->materials[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->materials[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->materials[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->materials[i].extensions);
+		cgltf_free_extensions(data, data->materials[i].extensions, data->materials[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->materials);
@@ -1709,12 +1619,7 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->images[i].uri);
 		data->memory.free(data->memory.user_data, data->images[i].mime_type);
 
-		for (cgltf_size j = 0; j < data->images[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->images[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->images[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->images[i].extensions);
+		cgltf_free_extensions(data, data->images[i].extensions, data->images[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->images);
@@ -1722,24 +1627,14 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->textures_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->textures[i].name);
-		for (cgltf_size j = 0; j < data->textures[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->textures[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->textures[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->textures[i].extensions);
+		cgltf_free_extensions(data, data->textures[i].extensions, data->textures[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->textures);
 
 	for (cgltf_size i = 0; i < data->samplers_count; ++i)
 	{
-		for (cgltf_size j = 0; j < data->samplers[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->samplers[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->samplers[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->samplers[i].extensions);
+		cgltf_free_extensions(data, data->samplers[i].extensions, data->samplers[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->samplers);
@@ -1749,12 +1644,7 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->skins[i].name);
 		data->memory.free(data->memory.user_data, data->skins[i].joints);
 
-		for (cgltf_size j = 0; j < data->skins[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->skins[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->skins[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->skins[i].extensions);
+		cgltf_free_extensions(data, data->skins[i].extensions, data->skins[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->skins);
@@ -1762,12 +1652,7 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->cameras_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->cameras[i].name);
-		for (cgltf_size j = 0; j < data->cameras[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->cameras[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->cameras[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->cameras[i].extensions);
+		cgltf_free_extensions(data, data->cameras[i].extensions, data->cameras[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->cameras);
@@ -1784,12 +1669,7 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->nodes[i].name);
 		data->memory.free(data->memory.user_data, data->nodes[i].children);
 		data->memory.free(data->memory.user_data, data->nodes[i].weights);
-		for (cgltf_size j = 0; j < data->nodes[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->nodes[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->nodes[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->nodes[i].extensions);
+		cgltf_free_extensions(data, data->nodes[i].extensions, data->nodes[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->nodes);
@@ -1799,12 +1679,7 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->scenes[i].name);
 		data->memory.free(data->memory.user_data, data->scenes[i].nodes);
 
-		for (cgltf_size j = 0; j < data->scenes[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->scenes[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->scenes[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->scenes[i].extensions);
+		cgltf_free_extensions(data, data->scenes[i].extensions, data->scenes[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->scenes);
@@ -1814,42 +1689,22 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->animations[i].name);
 		for (cgltf_size j = 0; j <  data->animations[i].samplers_count; ++j)
 		{
-			for (cgltf_size k = 0; k < data->animations[i].samplers[j].extensions_count; ++k)
-			{
-				data->memory.free(data->memory.user_data, data->animations[i].samplers[j].extensions[k].name);
-				data->memory.free(data->memory.user_data, data->animations[i].samplers[j].extensions[k].data);
-			}
-			data->memory.free(data->memory.user_data, data->animations[i].samplers[j].extensions);
+			cgltf_free_extensions(data, data->animations[i].samplers[j].extensions, data->animations[i].samplers[j].extensions_count);
 		}
 		data->memory.free(data->memory.user_data, data->animations[i].samplers);
 
 		for (cgltf_size j = 0; j <  data->animations[i].channels_count; ++j)
 		{
-			for (cgltf_size k = 0; k < data->animations[i].channels[j].extensions_count; ++k)
-			{
-				data->memory.free(data->memory.user_data, data->animations[i].channels[j].extensions[k].name);
-				data->memory.free(data->memory.user_data, data->animations[i].channels[j].extensions[k].data);
-			}
-			data->memory.free(data->memory.user_data, data->animations[i].channels[j].extensions);
+			cgltf_free_extensions(data, data->animations[i].channels[j].extensions, data->animations[i].channels[j].extensions_count);
 		}
 		data->memory.free(data->memory.user_data, data->animations[i].channels);
 
-		for (cgltf_size j = 0; j < data->animations[i].extensions_count; ++j)
-		{
-			data->memory.free(data->memory.user_data, data->animations[i].extensions[j].name);
-			data->memory.free(data->memory.user_data, data->animations[i].extensions[j].data);
-		}
-		data->memory.free(data->memory.user_data, data->animations[i].extensions);
+		cgltf_free_extensions(data, data->animations[i].extensions, data->animations[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->animations);
 
-	for (cgltf_size i = 0; i < data->data_extensions_count; ++i)
-	{
-		data->memory.free(data->memory.user_data, data->data_extensions[i].name);
-		data->memory.free(data->memory.user_data, data->data_extensions[i].data);
-	}
-	data->memory.free(data->memory.user_data, data->data_extensions);
+	cgltf_free_extensions(data, data->data_extensions, data->data_extensions_count);
 
 	for (cgltf_size i = 0; i < data->extensions_used_count; ++i)
 	{

--- a/cgltf.h
+++ b/cgltf.h
@@ -2736,30 +2736,10 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 				}
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 				{
-					++i;
-
-					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-					if(out_sparse->indices_extensions)
+					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->indices_extensions_count, &out_sparse->indices_extensions);
+					if (i < 0)
 					{
-						return CGLTF_ERROR_JSON;
-					}
-
-					int extensions_size = tokens[i].size;
-					out_sparse->indices_extensions_count = 0;
-					out_sparse->indices_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-					++i;
-
-					for (int l = 0; l < extensions_size; ++l)
-					{
-						CGLTF_CHECK_KEY(tokens[i]);
-
-						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->indices_extensions[out_sparse->indices_extensions_count++]));
-
-						if (i < 0)
-						{
-							return i;
-						}
+						return i;
 					}
 				}
 				else
@@ -2803,30 +2783,10 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 				}
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 				{
-					++i;
-
-					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-					if(out_sparse->values_extensions)
+					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->values_extensions_count, &out_sparse->values_extensions);
+					if (i < 0)
 					{
-						return CGLTF_ERROR_JSON;
-					}
-
-					int extensions_size = tokens[i].size;
-					out_sparse->values_extensions_count = 0;
-					out_sparse->values_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-					++i;
-
-					for (int l = 0; l < extensions_size; ++l)
-					{
-						CGLTF_CHECK_KEY(tokens[i]);
-
-						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_sparse->values_extensions[out_sparse->values_extensions_count++]));
-
-						if (i < 0)
-						{
-							return i;
-						}
+						return i;
 					}
 				}
 				else
@@ -4639,30 +4599,10 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 				}
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 				{
-					++i;
-
-					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-					if(out_channel->extensions)
+					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_channel->extensions_count, &out_channel->extensions);
+					if (i < 0)
 					{
-						return CGLTF_ERROR_JSON;
-					}
-
-					int extensions_size = tokens[i].size;
-					out_channel->extensions_count = 0;
-					out_channel->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-					++i;
-
-					for (int l = 0; l < extensions_size; ++l)
-					{
-						CGLTF_CHECK_KEY(tokens[i]);
-
-						i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_channel->extensions[out_channel->extensions_count++]));
-
-						if (i < 0)
-						{
-							return i;
-						}
+						return i;
 					}
 				}
 				else

--- a/cgltf.h
+++ b/cgltf.h
@@ -88,6 +88,14 @@
  * into the provided buffer. If `dest` is NULL, the length of the data is written into
  * `dest_size`. You can then parse this data using your own JSON parser
  * or, if you've included the cgltf implementation using the integrated JSMN JSON parser.
+ *
+ * `cgltf_result cgltf_copy_extension_json(const cgltf_data* data, const cgltf_extension* extension,
+ * char* dest, cgltf_size* dest_size)` allows users to retrieve the JSON data for extension that
+ * hasn't been processed by cgltf. The `cgltf_extension` struct stores name of extension and the
+ * offsets of the start and end of the extension JSON data as it appears in the complete glTF JSON
+ * data. This function copies the extension data into the provided buffer. If `dest` is NULL,
+ * the length of the data is written into `dest_size`. You can then parse this data using your own
+ * JSON parser or, if you've included the cgltf implementation using the integrated JSMN JSON parser.
  */
 #ifndef CGLTF_H_INCLUDED__
 #define CGLTF_H_INCLUDED__
@@ -689,6 +697,7 @@ cgltf_size cgltf_num_components(cgltf_type type);
 cgltf_size cgltf_accessor_unpack_floats(const cgltf_accessor* accessor, cgltf_float* out, cgltf_size float_count);
 
 cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* extras, char* dest, cgltf_size* dest_size);
+cgltf_result cgltf_copy_extension_json(const cgltf_data* data, const cgltf_extension* extension, char* dest, cgltf_size* dest_size);
 
 #ifdef __cplusplus
 }
@@ -1468,6 +1477,34 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 	else
 	{
 		strncpy(dest, data->json + extras->start_offset, json_size);
+		dest[json_size] = 0;
+	}
+
+	return cgltf_result_success;
+}
+
+cgltf_result cgltf_copy_extension_json(const cgltf_data* data, const cgltf_extension* extension, char* dest, cgltf_size* dest_size)
+{
+	cgltf_size json_size = extension->end_offset - extension->start_offset;
+
+	if (!dest)
+	{
+		if (dest_size)
+		{
+			*dest_size = json_size + 1;
+			return cgltf_result_success;
+		}
+		return cgltf_result_invalid_options;
+	}
+
+	if (*dest_size + 1 < json_size)
+	{
+		strncpy(dest, data->json + extension->start_offset, *dest_size - 1);
+		dest[*dest_size - 1] = 0;
+	}
+	else
+	{
+		strncpy(dest, data->json + extension->start_offset, json_size);
 		dest[json_size] = 0;
 	}
 


### PR DESCRIPTION
This adds "extensions" dictionary to objects, exposing extension name and start + end offsets. Simpler way would have been doing same way as extra.field, but I felt this to be better, as glTF 2.0 extensions-field has to be "[dictionary object](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#reference-extension)".

This could also be helpful for providing utility parsers for [vendor specific](https://github.com/jkuhlmann/cgltf/issues/103)/wip extensions in separate files.

Notes: 
1. I only implemented the reading part, didn't have plan to implement this for cgltf_write.h currently.
2. ~~"Draft pull request" as fuzzer still found some memory leaks but failures are only detected after 3+ hours.~~ edit: multithreaded fuzzing after 3h no longer gives leaks

Pseudo example usage:
```c
for (int i = 0; i < gltf->textures_count; ++i) {
    int source = gltf->textures[i].source;
    for (int j = 0; j < gltf->textures[i].extensions_count; ++j) {
        if (gltf->textures[i].extensions[j].name == "MSFT_texture_dds")  {
           source = process_dds_extension(gltf, &(gltf->textures[i].extensions[j]));
        }
    }
    load_image(gltf->images[source]);
}
```



