### PR TITLE
Add support for KHR_materials_transmission.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ cgltf also supports some glTF extensions:
 - KHR_draco_mesh_compression (requires a library like [Google's Draco](https://github.com/google/draco) for decompression though)
 - KHR_lights_punctual
 - KHR_materials_clearcoat
+- KHR_materials_transmission
 - KHR_materials_pbrSpecularGlossiness
 - KHR_materials_unlit
 - KHR_texture_transform

--- a/cgltf.h
+++ b/cgltf.h
@@ -397,15 +397,23 @@ typedef struct cgltf_clearcoat
 	cgltf_float clearcoat_roughness_factor;
 } cgltf_clearcoat;
 
+typedef struct cgltf_transmission
+{
+	cgltf_texture_view transmission_texture;
+	cgltf_float transmission_factor;
+} cgltf_transmission;
+
 typedef struct cgltf_material
 {
 	char* name;
 	cgltf_bool has_pbr_metallic_roughness;
 	cgltf_bool has_pbr_specular_glossiness;
 	cgltf_bool has_clearcoat;
+	cgltf_bool has_transmission;
 	cgltf_pbr_metallic_roughness pbr_metallic_roughness;
 	cgltf_pbr_specular_glossiness pbr_specular_glossiness;
 	cgltf_clearcoat clearcoat;
+	cgltf_transmission transmission;
 	cgltf_texture_view normal_texture;
 	cgltf_texture_view occlusion_texture;
 	cgltf_texture_view emissive_texture;
@@ -1645,6 +1653,10 @@ void cgltf_free(cgltf_data* data)
 			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_texture.extensions, data->materials[i].clearcoat.clearcoat_texture.extensions_count);
 			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions_count);
 			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions, data->materials[i].clearcoat.clearcoat_normal_texture.extensions_count);
+		}
+		if(data->materials[i].has_transmission)
+		{
+			cgltf_free_extensions(data, data->materials[i].transmission.transmission_texture.extensions, data->materials[i].transmission.transmission_texture.extensions_count);
 		}
 
 		cgltf_free_extensions(data, data->materials[i].normal_texture.extensions, data->materials[i].normal_texture.extensions_count);
@@ -3263,6 +3275,40 @@ static int cgltf_parse_json_clearcoat(cgltf_options* options, jsmntok_t const* t
 	return i;
 }
 
+static int cgltf_parse_json_transmission(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_transmission* out_transmission)
+{
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	int size = tokens[i].size;
+	++i;
+
+	for (int j = 0; j < size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		if (cgltf_json_strcmp(tokens+i, json_chunk, "transmissionFactor") == 0)
+		{
+			++i;
+			out_transmission->transmission_factor = cgltf_json_to_float(tokens + i, json_chunk);
+			++i;
+		}
+		else if (cgltf_json_strcmp(tokens+i, json_chunk, "transmissionTexture") == 0)
+		{
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_transmission->transmission_texture);
+		}
+		else
+		{
+			i = cgltf_skip_json(tokens, i+1);
+		}
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+
+	return i;
+}
+
 static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_image* out_image)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -3549,6 +3595,11 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				{
 					out_material->has_clearcoat = 1;
 					i = cgltf_parse_json_clearcoat(options, tokens, i + 1, json_chunk, &out_material->clearcoat);
+				}
+				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_transmission") == 0)
+				{
+					out_material->has_transmission = 1;
+					i = cgltf_parse_json_transmission(options, tokens, i + 1, json_chunk, &out_material->transmission);
 				}
 				else
 				{
@@ -5148,6 +5199,8 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_texture.texture, data->textures, data->textures_count);
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_roughness_texture.texture, data->textures, data->textures_count);
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_normal_texture.texture, data->textures, data->textures_count);
+
+		CGLTF_PTRFIXUP(data->materials[i].transmission.transmission_texture.texture, data->textures, data->textures_count);
 	}
 
 	for (cgltf_size i = 0; i < data->buffer_views_count; ++i)

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -75,6 +75,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #define CGLTF_EXTENSION_FLAG_LIGHTS_PUNCTUAL        (1 << 3)
 #define CGLTF_EXTENSION_FLAG_DRACO_MESH_COMPRESSION (1 << 4)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_CLEARCOAT    (1 << 5)
+#define CGLTF_EXTENSION_FLAG_MATERIALS_TRANSMISSION (1 << 6)
 
 typedef struct {
 	char* buffer;
@@ -502,6 +503,11 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_CLEARCOAT;
 	}
 
+	if (material->has_transmission)
+	{
+		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_TRANSMISSION;
+	}
+
 	if (material->has_pbr_metallic_roughness)
 	{
 		const cgltf_pbr_metallic_roughness* params = &material->pbr_metallic_roughness;
@@ -518,7 +524,7 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		cgltf_write_line(context, "}");
 	}
 
-	if (material->unlit || material->has_pbr_specular_glossiness || material->has_clearcoat)
+	if (material->unlit || material->has_pbr_specular_glossiness || material->has_clearcoat || material->has_transmission)
 	{
 		cgltf_write_line(context, "\"extensions\": {");
 		if (material->has_clearcoat)
@@ -530,6 +536,14 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 			CGLTF_WRITE_TEXTURE_INFO("clearcoatNormalTexture", params->clearcoat_normal_texture);
 			cgltf_write_floatprop(context, "clearcoatFactor", params->clearcoat_factor, 0.0f);
 			cgltf_write_floatprop(context, "clearcoatRoughnessFactor", params->clearcoat_roughness_factor, 0.0f);
+			cgltf_write_line(context, "}");
+		}
+		if (material->has_transmission)
+		{
+			const cgltf_transmission* params = &material->transmission;
+			cgltf_write_line(context, "\"KHR_materials_transmission\": {");
+			CGLTF_WRITE_TEXTURE_INFO("transmissionTexture", params->transmission_texture);
+			cgltf_write_floatprop(context, "transmissionFactor", params->transmission_factor, 0.0f);
 			cgltf_write_line(context, "}");
 		}
 		if (material->has_pbr_specular_glossiness)
@@ -899,6 +913,9 @@ static void cgltf_write_extensions(cgltf_write_context* context, uint32_t extens
 	}
 	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_CLEARCOAT) {
 		cgltf_write_stritem(context, "KHR_materials_clearcoat");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_TRANSMISSION) {
+		cgltf_write_stritem(context, "KHR_materials_transmission");
 	}
 }
 


### PR DESCRIPTION
Khronos has finalized the spec and is close to ratifying it. Filament
will be a reference implementation so we require cgltf support.

More information at:
https://github.com/KhronosGroup/glTF/pull/1698

ThreeJS support is arriving here:
https://github.com/mrdoob/three.js/pull/19690

@romainguy 