### PR TITLE
Add support for KHR_materials_specular

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ cgltf also supports some glTF extensions:
 - KHR_materials_clearcoat
 - KHR_materials_ior
 - KHR_materials_pbrSpecularGlossiness
+- KHR_materials_specular
 - KHR_materials_transmission
 - KHR_materials_unlit
 - KHR_texture_transform

--- a/cgltf.h
+++ b/cgltf.h
@@ -408,6 +408,13 @@ typedef struct cgltf_ior
 	cgltf_float ior;
 } cgltf_ior;
 
+typedef struct cgltf_specular
+{
+	cgltf_texture_view specular_texture;
+	cgltf_float specular_color_factor[3];
+	cgltf_float specular_factor;
+} cgltf_specular;
+
 typedef struct cgltf_material
 {
 	char* name;
@@ -416,10 +423,12 @@ typedef struct cgltf_material
 	cgltf_bool has_clearcoat;
 	cgltf_bool has_transmission;
 	cgltf_bool has_ior;
+	cgltf_bool has_specular;
 	cgltf_pbr_metallic_roughness pbr_metallic_roughness;
 	cgltf_pbr_specular_glossiness pbr_specular_glossiness;
 	cgltf_clearcoat clearcoat;
 	cgltf_ior ior;
+	cgltf_specular specular;
 	cgltf_transmission transmission;
 	cgltf_texture_view normal_texture;
 	cgltf_texture_view occlusion_texture;
@@ -1660,6 +1669,10 @@ void cgltf_free(cgltf_data* data)
 			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_texture.extensions, data->materials[i].clearcoat.clearcoat_texture.extensions_count);
 			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions_count);
 			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions, data->materials[i].clearcoat.clearcoat_normal_texture.extensions_count);
+		}
+		if(data->materials[i].has_specular)
+		{
+			cgltf_free_extensions(data, data->materials[i].specular.specular_texture.extensions, data->materials[i].specular.specular_texture.extensions_count);
 		}
 		if(data->materials[i].has_transmission)
 		{
@@ -3288,6 +3301,9 @@ static int cgltf_parse_json_ior(jsmntok_t const* tokens, int i, const uint8_t* j
 	int size = tokens[i].size;
 	++i;
 
+	// Default values
+	out_ior->ior = 1.5f;
+
 	for (int j = 0; j < size; ++j)
 	{
 		CGLTF_CHECK_KEY(tokens[i]);
@@ -3297,6 +3313,48 @@ static int cgltf_parse_json_ior(jsmntok_t const* tokens, int i, const uint8_t* j
 			++i;
 			out_ior->ior = cgltf_json_to_float(tokens + i, json_chunk);
 			++i;
+		}
+		else
+		{
+			i = cgltf_skip_json(tokens, i+1);
+		}
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+
+	return i;
+}
+
+static int cgltf_parse_json_specular(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_specular* out_specular)
+{
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	int size = tokens[i].size;
+	++i;
+
+	// Default values
+	out_specular->specular_factor = 1.0f;
+	cgltf_fill_float_array(out_specular->specular_color_factor, 3, 1.0f);
+
+	for (int j = 0; j < size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		if (cgltf_json_strcmp(tokens+i, json_chunk, "specularFactor") == 0)
+		{
+			++i;
+			out_specular->specular_factor = cgltf_json_to_float(tokens + i, json_chunk);
+			++i;
+		}
+		else if (cgltf_json_strcmp(tokens+i, json_chunk, "specularColorFactor") == 0)
+		{
+			i = cgltf_parse_json_float_array(tokens, i + 1, json_chunk, out_specular->specular_color_factor, 3);
+		}
+		else if (cgltf_json_strcmp(tokens+i, json_chunk, "specularTexture") == 0)
+		{
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_specular->specular_texture);
 		}
 		else
 		{
@@ -3637,6 +3695,11 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				{
 					out_material->has_ior = 1;
 					i = cgltf_parse_json_ior(tokens, i + 1, json_chunk, &out_material->ior);
+				}
+				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_specular") == 0)
+				{
+					out_material->has_specular = 1;
+					i = cgltf_parse_json_specular(options, tokens, i + 1, json_chunk, &out_material->specular);
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_transmission") == 0)
 				{
@@ -5241,6 +5304,8 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_texture.texture, data->textures, data->textures_count);
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_roughness_texture.texture, data->textures, data->textures_count);
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_normal_texture.texture, data->textures, data->textures_count);
+
+		CGLTF_PTRFIXUP(data->materials[i].specular.specular_texture.texture, data->textures, data->textures_count);
 
 		CGLTF_PTRFIXUP(data->materials[i].transmission.transmission_texture.texture, data->textures, data->textures_count);
 	}


### PR DESCRIPTION
The `KHR_materials_specular` extension is fairly simple and exposes three new parameters:
- `specularFactor`, float, default = `1.0f`
- `specularColorFactor`, float3, default = `{1.0f, 1.0f, 1.0f}`
- `specularTexture`, a 4-channel texture that combines `specularFactor` and `specularColorFactor`

This change has been tested by `test_write` using a [Khronos sample model](https://github.com/KhronosGroup/glTF-Sample-Models/pull/268).