### PR TITLE
Fix parsing of files with targetNames:null

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2687,7 +2687,7 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 				{
 					CGLTF_CHECK_KEY(tokens[i]);
 
-					if (cgltf_json_strcmp(tokens+i, json_chunk, "targetNames") == 0)
+					if (cgltf_json_strcmp(tokens+i, json_chunk, "targetNames") == 0 && tokens[i+1].type == JSMN_ARRAY)
 					{
 						i = cgltf_parse_json_string_array(options, tokens, i + 1, json_chunk, &out_mesh->target_names, &out_mesh->target_names_count);
 					}


### PR DESCRIPTION
targetNames isn't normative and as such can technically be something
other than an array. tinygltf seems to use targetNames:null in some
cases to designate an empty target array; cgltf previously would refuse
to parse files like this and now it discards non-array targetNames
values instead.