### PR TITLE
KHR_materials_specular now uses two textures, specularTexture and specularColorTexture

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1769,6 +1769,7 @@ void cgltf_free(cgltf_data* data)
 		if(data->materials[i].has_specular)
 		{
 			cgltf_free_extensions(data, data->materials[i].specular.specular_texture.extensions, data->materials[i].specular.specular_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].specular.specular_color_texture.extensions, data->materials[i].specular.specular_color_texture.extensions_count);
 		}
 		if(data->materials[i].has_transmission)
 		{
@@ -5599,6 +5600,7 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_normal_texture.texture, data->textures, data->textures_count);
 
 		CGLTF_PTRFIXUP(data->materials[i].specular.specular_texture.texture, data->textures, data->textures_count);
+		CGLTF_PTRFIXUP(data->materials[i].specular.specular_color_texture.texture, data->textures, data->textures_count);
 
 		CGLTF_PTRFIXUP(data->materials[i].transmission.transmission_texture.texture, data->textures, data->textures_count);
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -439,6 +439,7 @@ typedef struct cgltf_ior
 typedef struct cgltf_specular
 {
 	cgltf_texture_view specular_texture;
+	cgltf_texture_view specular_color_texture;
 	cgltf_float specular_color_factor[3];
 	cgltf_float specular_factor;
 } cgltf_specular;
@@ -3466,6 +3467,10 @@ static int cgltf_parse_json_specular(cgltf_options* options, jsmntok_t const* to
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "specularTexture") == 0)
 		{
 			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_specular->specular_texture);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "specularColorTexture") == 0)
+		{
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_specular->specular_color_texture);
 		}
 		else
 		{

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -575,6 +575,7 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 			const cgltf_specular* params = &material->specular;
 			cgltf_write_line(context, "\"KHR_materials_specular\": {");
 			CGLTF_WRITE_TEXTURE_INFO("specularTexture", params->specular_texture);
+			CGLTF_WRITE_TEXTURE_INFO("specularColorTexture", params->specular_color_texture);
 			cgltf_write_floatprop(context, "specularFactor", params->specular_factor, 1.0f);
 			if (cgltf_check_floatarray(params->specular_color_factor, 3, 1.0f))
 			{


### PR DESCRIPTION
KHR_materials_specular definition was tweaked this week; specularTexture is now broken apart into two textures, specularColorTexture (RGB) and specularTexture (A). 

This change in the draft specification follows the convention used by many of glTF's other extensions, where colors and factors are specified as separate textures in the extension (e.g. sheenColorTexture and sheenRoughnessTexture).  This allows for flexibility in how the texture data is packed.  This new arrangement also allows for specularColorTexture and specularTexture to have a unique texture_transforms if necessary.

/CC @emackey