### PR TITLE
Added support for KHR_materials_volume.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ cgltf also supports some glTF extensions:
 - KHR_materials_transmission
 - KHR_materials_unlit
 - KHR_materials_variants
+- KHR_materials_volume
 - KHR_texture_transform
 
 cgltf does **not** yet support unlisted extensions. However, unlisted extensions can be accessed via "extensions" member on objects.

--- a/cgltf.h
+++ b/cgltf.h
@@ -805,6 +805,7 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 #include <string.h> /* For strncpy */
 #include <stdio.h>  /* For fopen */
 #include <limits.h> /* For UINT_MAX etc */
+#include <float.h>  /* For FLT_MAX */
 
 #if !defined(CGLTF_MALLOC) || !defined(CGLTF_FREE) || !defined(CGLTF_ATOI) || !defined(CGLTF_ATOF)
 #include <stdlib.h> /* For malloc, free, atoi, atof */

--- a/cgltf.h
+++ b/cgltf.h
@@ -3793,6 +3793,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 	out_material->pbr_specular_glossiness.glossiness_factor = 1.0f;
 
 	cgltf_fill_float_array(out_material->volume.attenuation_color, 3, 1.0f);
+	out_material->volume.attenuation_distance = FLT_MAX;
 
 	out_material->alpha_cutoff = 0.5f;
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -443,6 +443,14 @@ typedef struct cgltf_specular
 	cgltf_float specular_factor;
 } cgltf_specular;
 
+typedef struct cgltf_volume
+{
+	cgltf_texture_view thickness_texture;
+	cgltf_float thickness_factor;
+	cgltf_float attenuation_color[3];
+	cgltf_float attenuation_distance;
+} cgltf_volume;
+
 typedef struct cgltf_sheen
 {
 	cgltf_texture_view sheen_color_texture;
@@ -458,6 +466,7 @@ typedef struct cgltf_material
 	cgltf_bool has_pbr_specular_glossiness;
 	cgltf_bool has_clearcoat;
 	cgltf_bool has_transmission;
+	cgltf_bool has_volume;
 	cgltf_bool has_ior;
 	cgltf_bool has_specular;
 	cgltf_bool has_sheen;
@@ -468,6 +477,7 @@ typedef struct cgltf_material
 	cgltf_specular specular;
 	cgltf_sheen sheen;
 	cgltf_transmission transmission;
+	cgltf_volume volume;
 	cgltf_texture_view normal_texture;
 	cgltf_texture_view occlusion_texture;
 	cgltf_texture_view emissive_texture;
@@ -1772,6 +1782,10 @@ void cgltf_free(cgltf_data* data)
 		if(data->materials[i].has_transmission)
 		{
 			cgltf_free_extensions(data, data->materials[i].transmission.transmission_texture.extensions, data->materials[i].transmission.transmission_texture.extensions_count);
+		}
+		if (data->materials[i].has_volume)
+		{
+			cgltf_free_extensions(data, data->materials[i].volume.thickness_texture.extensions, data->materials[i].volume.thickness_texture.extensions_count);
 		}
 		if(data->materials[i].has_sheen)
 		{
@@ -3515,6 +3529,50 @@ static int cgltf_parse_json_transmission(cgltf_options* options, jsmntok_t const
 	return i;
 }
 
+static int cgltf_parse_json_volume(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_volume* out_volume)
+{
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	int size = tokens[i].size;
+	++i;
+
+	for (int j = 0; j < size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		if (cgltf_json_strcmp(tokens + i, json_chunk, "thicknessFactor") == 0)
+		{
+			++i;
+			out_volume->thickness_factor = cgltf_json_to_float(tokens + i, json_chunk);
+			++i;
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "thicknessTexture") == 0)
+		{
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_volume->thickness_texture);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "attenuationColor") == 0)
+		{
+			i = cgltf_parse_json_float_array(tokens, i + 1, json_chunk, out_volume->attenuation_color, 3);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "attenuationDistance") == 0)
+		{
+			++i;
+			out_volume->attenuation_distance = cgltf_json_to_float(tokens + i, json_chunk);
+			++i;
+		}
+		else
+		{
+			i = cgltf_skip_json(tokens, i + 1);
+		}
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+
+	return i;
+}
+
 static int cgltf_parse_json_sheen(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_sheen* out_sheen)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -3734,6 +3792,8 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 	cgltf_fill_float_array(out_material->pbr_specular_glossiness.specular_factor, 3, 1.0f);
 	out_material->pbr_specular_glossiness.glossiness_factor = 1.0f;
 
+	cgltf_fill_float_array(out_material->volume.attenuation_color, 3, 1.0f);
+
 	out_material->alpha_cutoff = 0.5f;
 
 	int size = tokens[i].size;
@@ -3858,6 +3918,11 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				{
 					out_material->has_transmission = 1;
 					i = cgltf_parse_json_transmission(options, tokens, i + 1, json_chunk, &out_material->transmission);
+				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "KHR_materials_volume") == 0)
+				{
+					out_material->has_volume = 1;
+					i = cgltf_parse_json_volume(options, tokens, i + 1, json_chunk, &out_material->volume);
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_sheen") == 0)
 				{
@@ -5596,6 +5661,8 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 		CGLTF_PTRFIXUP(data->materials[i].specular.specular_texture.texture, data->textures, data->textures_count);
 
 		CGLTF_PTRFIXUP(data->materials[i].transmission.transmission_texture.texture, data->textures, data->textures_count);
+
+		CGLTF_PTRFIXUP(data->materials[i].volume.thickness_texture.texture, data->textures, data->textures_count);
 
 		CGLTF_PTRFIXUP(data->materials[i].sheen.sheen_color_texture.texture, data->textures, data->textures_count);
 		CGLTF_PTRFIXUP(data->materials[i].sheen.sheen_roughness_texture.texture, data->textures, data->textures_count);

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -68,6 +68,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <float.h>
 
 #define CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM      (1 << 0)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_UNLIT        (1 << 1)

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -606,11 +606,9 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 			{
 				cgltf_write_floatarrayprop(context, "attenuationColor", params->attenuation_color, 3);
 			}
-			// attenuation_distance of 0.0 isn't allowed (it implies this material is opaque);
-			// assuming a value of 0.0 implies the default value of Infinity.
-			if (params->attenuation_distance > 0.0) 
+			if (params->attenuation_distance < FLT_MAX) 
 			{
-				cgltf_write_floatprop(context, "attenuationDistance", params->attenuation_distance, 0.0f);
+				cgltf_write_floatprop(context, "attenuationDistance", params->attenuation_distance, FLT_MAX);
 			}
 			cgltf_write_line(context, "}");
 		}

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -79,6 +79,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #define CGLTF_EXTENSION_FLAG_MATERIALS_SPECULAR     (1 << 7)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_TRANSMISSION (1 << 8)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_SHEEN        (1 << 9)
+#define CGLTF_EXTENSION_FLAG_MATERIALS_VOLUME       (1 << 10)
 
 typedef struct {
 	char* buffer;
@@ -518,6 +519,11 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_TRANSMISSION;
 	}
 
+	if (material->has_volume)
+	{
+		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_VOLUME;
+	}
+
 	if (material->has_ior)
 	{
 		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_IOR;
@@ -549,7 +555,7 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		cgltf_write_line(context, "}");
 	}
 
-	if (material->unlit || material->has_pbr_specular_glossiness || material->has_clearcoat || material->has_ior || material->has_specular || material->has_transmission || material->has_sheen)
+	if (material->unlit || material->has_pbr_specular_glossiness || material->has_clearcoat || material->has_ior || material->has_specular || material->has_transmission || material->has_sheen || material->has_volume)
 	{
 		cgltf_write_line(context, "\"extensions\": {");
 		if (material->has_clearcoat)
@@ -588,6 +594,24 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 			cgltf_write_line(context, "\"KHR_materials_transmission\": {");
 			CGLTF_WRITE_TEXTURE_INFO("transmissionTexture", params->transmission_texture);
 			cgltf_write_floatprop(context, "transmissionFactor", params->transmission_factor, 0.0f);
+			cgltf_write_line(context, "}");
+		}
+		if (material->has_volume)
+		{
+			const cgltf_volume* params = &material->volume;
+			cgltf_write_line(context, "\"KHR_materials_volume\": {");
+			CGLTF_WRITE_TEXTURE_INFO("thicknessTexture", params->thickness_texture);
+			cgltf_write_floatprop(context, "thicknessFactor", params->thickness_factor, 0.0f);
+			if (cgltf_check_floatarray(params->attenuation_color, 3, 1.0f))
+			{
+				cgltf_write_floatarrayprop(context, "attenuationColor", params->attenuation_color, 3);
+			}
+			// attenuation_distance of 0.0 isn't allowed (it implies this material is opaque);
+			// assuming a value of 0.0 implies the default value of Infinity.
+			if (params->attenuation_distance > 0.0) 
+			{
+				cgltf_write_floatprop(context, "attenuationDistance", params->attenuation_distance, 0.0f);
+			}
 			cgltf_write_line(context, "}");
 		}
 		if (material->has_sheen)


### PR DESCRIPTION
This extension enables reading and writing of refractive volumes, as defined by the draft extension, KHR_materials_volume.

See: https://github.com/KhronosGroup/glTF/pull/1726