### PR TITLE
Fix a few parsing crashes on invalid inputs

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2655,6 +2655,7 @@ static int cgltf_parse_json_draco_mesh_compression(cgltf_options* options, jsmnt
 
 static int cgltf_parse_json_material_mapping_data(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_material_mapping* out_mappings, cgltf_size* offset)
 {
+	(void)options;
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_ARRAY);
 
 	int size = tokens[i].size;

--- a/cgltf.h
+++ b/cgltf.h
@@ -2643,6 +2643,11 @@ static int cgltf_parse_json_draco_mesh_compression(cgltf_options* options, jsmnt
 			out_draco_mesh_compression->buffer_view = CGLTF_PTRINDEX(cgltf_buffer_view, cgltf_json_to_int(tokens + i, json_chunk));
 			++i;
 		}
+
+		if (i < 0)
+		{
+			return i;
+		}
 	}
 
 	return i;

--- a/cgltf.h
+++ b/cgltf.h
@@ -2668,6 +2668,8 @@ static int cgltf_parse_json_material_mapping_data(cgltf_options* options, jsmnto
 
 		for (int k = 0; k < obj_size; ++k)
 		{
+			CGLTF_CHECK_KEY(tokens[i]);
+
 			if (cgltf_json_strcmp(tokens + i, json_chunk, "material") == 0)
 			{
 				++i;
@@ -2688,6 +2690,11 @@ static int cgltf_parse_json_material_mapping_data(cgltf_options* options, jsmnto
 			else
 			{
 				i = cgltf_skip_json(tokens, i+1);
+			}
+
+			if (i < 0)
+			{
+				return i;
 			}
 		}
 
@@ -2754,6 +2761,11 @@ static int cgltf_parse_json_material_mappings(cgltf_options* options, jsmntok_t 
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
+		}
+
+		if (i < 0)
+		{
+			return i;
 		}
 	}
 

--- a/fuzz/main.c
+++ b/fuzz/main.c
@@ -10,7 +10,7 @@ cp -r data temp
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
-	cgltf_options options = {0};
+	cgltf_options options = {cgltf_file_type_invalid};
 	cgltf_data* data = NULL;
 	cgltf_result res = cgltf_parse(&options, Data, Size, &data);
 	if (res == cgltf_result_success)


### PR DESCRIPTION
This is mostly a followup for #132 since I forgot a few error checks there, but I've also ran the fuzzer for a few hours and found one more problem in Draco mesh compression parsing (also on invalid files).