### PR TITLE
Fix ANSI C build

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2670,7 +2670,7 @@ static int cgltf_parse_json_material_mapping_data(cgltf_options* options, jsmnto
 
 		int material = -1;
 		int variants_tok = -1;
-		cgltf_extras extras = {};
+		cgltf_extras extras = {0};
 
 		for (int k = 0; k < obj_size; ++k)
 		{


### PR DESCRIPTION
This fixes the -Wpedantic warning which is triggering a build failure.

For some reason this isn't visible in PR statuses, and only shows up upon merge :( I think we saw odd issues with Travis before on this repository but it wasn't clear why they happened...