### PR TITLE
Add perspective camera aspect ratio and zfar property flags

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -554,8 +554,10 @@ typedef struct cgltf_skin {
 } cgltf_skin;
 
 typedef struct cgltf_camera_perspective {
+	cgltf_bool has_aspect_ratio;
 	cgltf_float aspect_ratio;
 	cgltf_float yfov;
+	cgltf_bool has_zfar;
 	cgltf_float zfar;
 	cgltf_float znear;
 	cgltf_extras extras;
@@ -4647,6 +4649,7 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 				if (cgltf_json_strcmp(tokens+i, json_chunk, "aspectRatio") == 0)
 				{
 					++i;
+					out_camera->data.perspective.has_aspect_ratio = 1;
 					out_camera->data.perspective.aspect_ratio = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}
@@ -4659,6 +4662,7 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "zfar") == 0)
 				{
 					++i;
+					out_camera->data.perspective.has_zfar = 1;
 					out_camera->data.perspective.zfar = cgltf_json_to_float(tokens + i, json_chunk);
 					++i;
 				}

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -944,9 +944,17 @@ static void cgltf_write_camera(cgltf_write_context* context, const cgltf_camera*
 	else if (camera->type == cgltf_camera_type_perspective)
 	{
 		cgltf_write_line(context, "\"perspective\": {");
-		cgltf_write_floatprop(context, "aspectRatio", camera->data.perspective.aspect_ratio, -1.0f);
+
+		if (camera->data.perspective.has_aspect_ratio) {
+			cgltf_write_floatprop(context, "aspectRatio", camera->data.perspective.aspect_ratio, -1.0f);
+		}
+
 		cgltf_write_floatprop(context, "yfov", camera->data.perspective.yfov, -1.0f);
-		cgltf_write_floatprop(context, "zfar", camera->data.perspective.zfar, -1.0f);
+
+		if (camera->data.perspective.has_zfar) {
+			cgltf_write_floatprop(context, "zfar", camera->data.perspective.zfar, -1.0f);
+		}
+
 		cgltf_write_floatprop(context, "znear", camera->data.perspective.znear, -1.0f);
 		cgltf_write_extras(context, &camera->data.perspective.extras);
 		cgltf_write_line(context, "}");


### PR DESCRIPTION
The perspective camera's `aspectRatio` and `zfar` are [both optional](https://github.com/KhronosGroup/glTF/blob/f16e9846d741f0acaa46918c8d71cf6093a0f14a/specification/2.0/schema/camera.perspective.schema.json#L38). Previously, if you ran `test_write` on

```json
{
    "asset": {
        "version": "2.0"
    },
    "cameras": [
        {
          "type": "perspective",
          "perspective": {
            "yfov": 0.5,
            "znear": 0.01
          }
        }
    ]
}
```

it would treat the aspect ratio and zfar both as zero

```json
{
  "asset": {
    "version": "2.0"
  },
  "cameras": [
    {
      "type": "perspective",
      "perspective": {
        "aspectRatio": 0,
        "yfov": 0.5,
        "zfar": 0,
        "znear": 0.00999999978
      }
    }
  ]
}
```

With this change, `test_write` will produce

```json
{
  "asset": {
    "version": "2.0"
  },
  "cameras": [
    {
      "type": "perspective",
      "perspective": {
        "yfov": 0.5,
        "znear": 0.00999999978
      }
    }
  ]
}
```