### PR TITLE
Minor updates to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ if (result == cgltf_result_success)
 ```
 
 Note that cgltf does not load the contents of extra files such as buffers or images into memory by default. You'll need to read these files yourself using URIs from `data.buffers[]` or `data.images[]` respectively.
-For buffer data, you can alternatively call `cgltf_load_buffers`, which will use `FILE*` APIs to open and read buffer files.
+For buffer data, you can alternatively call `cgltf_load_buffers`, which will use `FILE*` APIs to open and read buffer files. This automatically decodes base64 data URIs in buffers. For data URIs in images, you will need to use `cgltf_load_buffer_base64`.
 
 **For more in-depth documentation and a description of the public interface refer to the top of the `cgltf.h` file.**
 
@@ -82,8 +82,6 @@ if (written != size)
 ```
 
 Note that cgltf does not write the contents of extra files such as buffers or images. You'll need to write this data yourself.
-
-Writing does not yet support "extras" data.
 
 **For more in-depth documentation and a description of the public interface refer to the top of the `cgltf_write.h` file.**
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -24,7 +24,7 @@
  *
  * `cgltf_options` is the struct passed to `cgltf_parse()` to control
  * parts of the parsing process. You can use it to force the file type
- * and provide memory allocation as well as file operation callbacks. 
+ * and provide memory allocation as well as file operation callbacks.
  * Should be zero-initialized to trigger default behavior.
  *
  * `cgltf_data` is the struct allocated and filled by `cgltf_parse()`.
@@ -42,8 +42,8 @@
  *
  * `cgltf_result cgltf_load_buffer_base64(const cgltf_options* options,
  * cgltf_size size, const char* base64, void** out_data)` decodes
- * base64-encoded data content. Used internally by `cgltf_load_buffers()`
- * and may be useful if you're not dealing with normal files.
+ * base64-encoded data content. Used internally by `cgltf_load_buffers()`.
+ * This is useful when decoding data URIs in images.
  *
  * `cgltf_result cgltf_parse_file(const cgltf_options* options, const
  * char* path, cgltf_data** out_data)` can be used to open the given


### PR DESCRIPTION
- `cgltf_write` *does* support extras.
- Add some notes about decoding image URIs.