### PR TITLE
Add KHR_texture_basisu parsing

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -372,6 +372,8 @@ typedef struct cgltf_texture
 	char* name;
 	cgltf_image* image;
 	cgltf_sampler* sampler;
+	cgltf_bool has_basisu;
+	cgltf_image* basisu_image;
 	cgltf_extras extras;
 	cgltf_size extensions_count;
 	cgltf_extension* extensions;
@@ -3885,7 +3887,58 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
-			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_texture->extensions_count, &out_texture->extensions);
+			++i;
+
+			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if (out_texture->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
+
+			int extensions_size = tokens[i].size;
+			++i;
+			out_texture->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
+			out_texture->extensions_count = 0;
+
+			if (!out_texture->extensions)
+			{
+				return CGLTF_ERROR_NOMEM;
+			}
+
+			for (int k = 0; k < extensions_size; ++k)
+			{
+				CGLTF_CHECK_KEY(tokens[i]);
+
+				if (cgltf_json_strcmp(tokens + i, json_chunk, "KHR_texture_basisu") == 0)
+				{
+					out_texture->has_basisu = 1;
+					++i;
+					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+					int size = tokens[i].size;
+					++i;
+
+					for (int t = 0; t < size; ++t)
+					{
+						CGLTF_CHECK_KEY(tokens[i]);
+
+						if (cgltf_json_strcmp(tokens + i, json_chunk, "source") == 0)
+						{
+							++i;
+							out_texture->basisu_image = CGLTF_PTRINDEX(cgltf_image, cgltf_json_to_int(tokens + i, json_chunk));
+							++i;
+						}
+					}
+				}
+				else
+				{
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture->extensions[out_texture->extensions_count++]));
+				}
+
+				if (i < 0)
+				{
+					return i;
+				}
+			}
 		}
 		else
 		{
@@ -5851,6 +5904,7 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->textures_count; ++i)
 	{
 		CGLTF_PTRFIXUP(data->textures[i].image, data->images, data->images_count);
+		CGLTF_PTRFIXUP(data->textures[i].basisu_image, data->images, data->images_count);
 		CGLTF_PTRFIXUP(data->textures[i].sampler, data->samplers, data->samplers_count);
 	}
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -3914,10 +3914,10 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 					out_texture->has_basisu = 1;
 					++i;
 					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-					int size = tokens[i].size;
+					int num_properties = tokens[i].size;
 					++i;
 
-					for (int t = 0; t < size; ++t)
+					for (int t = 0; t < num_properties; ++t)
 					{
 						CGLTF_CHECK_KEY(tokens[i]);
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -3927,6 +3927,10 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 							out_texture->basisu_image = CGLTF_PTRINDEX(cgltf_image, cgltf_json_to_int(tokens + i, json_chunk));
 							++i;
 						}
+						else
+						{
+							i = cgltf_skip_json(tokens, i + 1);
+						}
 					}
 				}
 				else

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -82,6 +82,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #define CGLTF_EXTENSION_FLAG_MATERIALS_SHEEN        (1 << 9)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_VARIANTS     (1 << 10)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_VOLUME       (1 << 11)
+#define CGLTF_EXTENSION_FLAG_TEXTURE_BASISU        (1 << 12)
 
 typedef struct {
 	char* buffer;
@@ -707,6 +708,18 @@ static void cgltf_write_texture(cgltf_write_context* context, const cgltf_textur
 	cgltf_write_strprop(context, "name", texture->name);
 	CGLTF_WRITE_IDXPROP("source", texture->image, context->data->images);
 	CGLTF_WRITE_IDXPROP("sampler", texture->sampler, context->data->samplers);
+
+	if (texture->has_basisu)
+	{
+		cgltf_write_line(context, "\"extensions\": {");
+		{
+			context->extension_flags |= CGLTF_EXTENSION_FLAG_TEXTURE_BASISU;
+			cgltf_write_line(context, "\"KHR_texture_basisu\": {");
+			CGLTF_WRITE_IDXPROP("source", texture->basisu_image, context->data->images);
+			cgltf_write_line(context, "}");
+		}
+		cgltf_write_line(context, "}");
+	}
 	cgltf_write_extras(context, &texture->extras);
 	cgltf_write_line(context, "}");
 }
@@ -1058,6 +1071,12 @@ static void cgltf_write_extensions(cgltf_write_context* context, uint32_t extens
 	}
 	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_VARIANTS) {
 		cgltf_write_stritem(context, "KHR_materials_variants");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_VOLUME) {
+		cgltf_write_stritem(context, "KHR_materials_volume");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_TEXTURE_BASISU) {
+		cgltf_write_stritem(context, "KHR_texture_basisu");
 	}
 }
 


### PR DESCRIPTION
Adds support for https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_basisu

In the glTF file, this extension is defined on the texture object, so it seems logical that we define this cgltf extension data on the `cgltf_texture` object. This PR adds a new flag, `has_basisu` and a new `cgltf_image` property, `basisu_image` to `cgltf_texture`.  This solution allows loaders that do not support KTX2 and basisu textures to continue loading any fallback texture that may be defined on the model.

I considered making a small change, where we can `#define SUPPORT_BASISU`, remove this new `cgltf_texture::basisu_image`, and instead just load the basisu image directly into `cgltf_texture::image`.  Open to suggestions here, but both seem functionally equivalent.

If you'd like to play with this extension, here are some helpful resources to get started:
 * Instructions for converting existing glTF model textures to KTX2+basisu can be found in the artist guide: https://github.com/KhronosGroup/3D-Formats-Guidelines/blob/main/KTXArtistGuide.md
 * A developers guide for KTX2 and basisu can be found here: https://github.com/KhronosGroup/3D-Formats-Guidelines/blob/main/KTXDeveloperGuide.md
 * To load basisu textures into your engine, you'll only need the `basisu_transcoder.cpp` from [Binomial](https://github.com/BinomialLLC/basis_universal). The transcoder also defines a helpful and compact ktx2 loader. See [How to configure and use the transcoder](https://github.com/BinomialLLC/basis_universal/wiki/How-to-Use-and-Configure-the-Transcoder) for tips to get started.
