### PR TITLE
Fix format-truncation warning for gcc

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -64,6 +64,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 
 #ifdef CGLTF_WRITE_IMPLEMENTATION
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -109,6 +110,7 @@ typedef struct {
 #endif
 
 #define CGLTF_SPRINTF(...) { \
+		assert(context->cursor || (!context->cursor && context->remaining == 0)); \
 		context->tmp = snprintf ( context->cursor, context->remaining, __VA_ARGS__ ); \
 		context->chars_written += context->tmp; \
 		if (context->cursor) { \
@@ -117,6 +119,7 @@ typedef struct {
 		} }
 
 #define CGLTF_SNPRINTF(length, ...) { \
+		assert(context->cursor || (!context->cursor && context->remaining == 0)); \
 		context->tmp = snprintf ( context->cursor, CGLTF_MIN(length + 1, context->remaining), __VA_ARGS__ ); \
 		context->chars_written += length; \
 		if (context->cursor) { \


### PR DESCRIPTION
In newer gcc versions (tested on gcc 11.1.0) compiling with `-O2 -Wall -Werror` flags produces warnings like
```
In file included from /cgltf/test/test_write.cpp:3:
In function ‘void cgltf_write_node(cgltf_write_context*, const cgltf_node*)’,
    inlined from ‘cgltf_size cgltf_write(const cgltf_options*, char*, cgltf_size, const cgltf_data*)’ at /cgltf/test/../cgltf_write.h:1183:20:
/cgltf/test/../cgltf_write.h:112:41: error: null destination pointer [-Werror=format-truncation=]
  112 |                 context->tmp = snprintf ( context->cursor, context->remaining, __VA_ARGS__ ); \
      |                                ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cgltf/test/../cgltf_write.h:138:25: note: in expansion of macro ‘CGLTF_SPRINTF’
  138 |                         CGLTF_SPRINTF(" %d", idx); \
      |                         ^~~~~~~~~~~~~
/cgltf/test/../cgltf_write.h:857:9: note: in expansion of macro ‘CGLTF_WRITE_IDXARRPROP’
  857 |         CGLTF_WRITE_IDXARRPROP("children", node->children_count, node->children, context->data->nodes);
      |         ^~~~~~~~~~~~~~~~~~~~~~
```

This patch adds additional check for non zero buffer size with null buffer in snprintf, which solves the warning.