### PR TITLE
Fix memory overlap in cgltf_decode_string

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1276,15 +1276,19 @@ void cgltf_decode_string(char* string)
 	char* write = string;
 	char* last = string;
 
-	while (read)
+	for (;;)
 	{
 		// Copy characters since last escaped sequence
 		cgltf_size written = read - last;
-		strncpy(write, last, written);
+		memmove(write, last, written);
 		write += written;
 
+		if (*read++ == 0)
+		{
+			break;
+		}
+
 		// jsmn already checked that all escape sequences are valid
-		++read;
 		switch (*read++)
 		{
 		case '\"': *write++ = '\"'; break;
@@ -1326,10 +1330,10 @@ void cgltf_decode_string(char* string)
 		}
 
 		last = read;
-		read = strchr(read, '\\');
+		read += strcspn(read, "\\");
 	}
 
-	strcpy(write, last);
+	*write = 0;
 }
 
 void cgltf_decode_uri(char* uri)


### PR DESCRIPTION
This fixes some undefined behaviour in `cgltf_decode_string` added in https://github.com/jkuhlmann/cgltf/pull/165. Overlapping memory in any of the `str*` functions turns out to be UB caught by ASan.

It might be worth adding `target_link_libraries(${EXE_NAME} -fsanitize=address)` to the test CMake targets to catch similar errors in the future.