### PR TITLE
Return new length from string decoding functions

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -779,8 +779,8 @@ cgltf_result cgltf_load_buffers(
 
 cgltf_result cgltf_load_buffer_base64(const cgltf_options* options, cgltf_size size, const char* base64, void** out_data);
 
-void cgltf_decode_string(char* string);
-void cgltf_decode_uri(char* uri);
+cgltf_size cgltf_decode_string(char* string);
+cgltf_size cgltf_decode_uri(char* uri);
 
 cgltf_result cgltf_validate(cgltf_data* data);
 
@@ -1266,12 +1266,12 @@ static int cgltf_unhex(char ch)
 		-1;
 }
 
-void cgltf_decode_string(char* string)
+cgltf_size cgltf_decode_string(char* string)
 {
-	char* read = strchr(string, '\\');
-	if (read == NULL)
+	char* read = string + strcspn(string, "\\");
+	if (*read == 0)
 	{
-		return;
+		return read - string;
 	}
 	char* write = string;
 	char* last = string;
@@ -1334,9 +1334,10 @@ void cgltf_decode_string(char* string)
 	}
 
 	*write = 0;
+	return write - string;
 }
 
-void cgltf_decode_uri(char* uri)
+cgltf_size cgltf_decode_uri(char* uri)
 {
 	char* write = uri;
 	char* i = uri;
@@ -1364,6 +1365,7 @@ void cgltf_decode_uri(char* uri)
 	}
 
 	*write = 0;
+	return write - uri;
 }
 
 cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, const char* gltf_path)

--- a/test/test_strings.cpp
+++ b/test/test_strings.cpp
@@ -1,8 +1,10 @@
 #define CGLTF_IMPLEMENTATION
 #include "../cgltf.h"
 
-static void check(const char* a, const char* b) {
-    if (strcmp(a, b) != 0) {
+#include <cstring>
+
+static void check(const char* a, const char* b, cgltf_size size) {
+    if (strcmp(a, b) != 0 || strlen(a) != size) {
         fprintf(stderr, "Mismatch detected.\n");
         exit(1);
     }
@@ -11,44 +13,45 @@ static void check(const char* a, const char* b) {
 int main(int, char**)
 {
     char string[64];
+    cgltf_size size;
 
     // cgltf_decode_string
     strcpy(string, "");
-    cgltf_decode_string(string);
-    check(string, "");
+    size = cgltf_decode_string(string);
+    check(string, "", size);
 
     strcpy(string, "nothing to replace");
-    cgltf_decode_string(string);
-    check(string, "nothing to replace");
+    size = cgltf_decode_string(string);
+    check(string, "nothing to replace", size);
 
     strcpy(string, "\\\" \\/ \\\\ \\b \\f \\r \\n \\t \\u0030");
-    cgltf_decode_string(string);
-    check(string, "\" / \\ \b \f \r \n \t 0");
+    size = cgltf_decode_string(string);
+    check(string, "\" / \\ \b \f \r \n \t 0", size);
 
     strcpy(string, "test \\u121b\\u130d\\u1294\\u1276\\u127d test");
-    cgltf_decode_string(string);
-    check(string, "test ማግኔቶች test");
+    size = cgltf_decode_string(string);
+    check(string, "test ማግኔቶች test", size);
 
     // cgltf_decode_uri
     strcpy(string, "");
-    cgltf_decode_uri(string);
-    check(string, "");
+    size = cgltf_decode_uri(string);
+    check(string, "", size);
 
     strcpy(string, "nothing to replace");
-    cgltf_decode_uri(string);
-    check(string, "nothing to replace");
+    size = cgltf_decode_uri(string);
+    check(string, "nothing to replace", size);
 
     strcpy(string, "%2F%D0%BA%D0%B8%D1%80%D0%B8%D0%BB%D0%BB%D0%B8%D1%86%D0%B0");
-    cgltf_decode_uri(string);
-    check(string, "/кириллица");
+    size = cgltf_decode_uri(string);
+    check(string, "/кириллица", size);
 
     strcpy(string, "test%20%E1%88%9B%E1%8C%8D%E1%8A%94%E1%89%B6%E1%89%BD%20test"); 
-    cgltf_decode_uri(string);
-    check(string, "test ማግኔቶች test");
+    size = cgltf_decode_uri(string);
+    check(string, "test ማግኔቶች test", size);
 
     strcpy(string, "%%2F%X%AX%%2F%%");
-    cgltf_decode_uri(string);
-    check(string, "%/%X%AX%/%%");
+    size = cgltf_decode_uri(string);
+    check(string, "%/%X%AX%/%%", size);
 
     return 0;
 }


### PR DESCRIPTION
Suggestion for a minor convenience change to make the `cgtf_decode_*` functions return the new string length after decoding.

Useful if you want to re-allocate to save memory, and calling `strlen` seemed unnecessary since the functions should know the new length.