### PR TITLE
Add support for KHR_materials_emissive_strength.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ cgltf also supports some glTF extensions:
 - KHR_materials_variants
 - KHR_materials_volume
 - KHR_texture_transform
+- KHR_texture_basisu (requires a library like [Binomial Basisu](https://github.com/BinomialLLC/basis_universal) for transcoding to native compressed texture)
+- KHR_materials_emissive_strength
 
 cgltf does **not** yet support unlisted extensions. However, unlisted extensions can be accessed via "extensions" member on objects.
 

--- a/cgltf.h
+++ b/cgltf.h
@@ -474,6 +474,11 @@ typedef struct cgltf_sheen
 	cgltf_float sheen_roughness_factor;
 } cgltf_sheen;
 
+typedef struct cgltf_emissive_strength
+{
+	cgltf_float emissive_strength;
+} cgltf_emissive_strength;
+
 typedef struct cgltf_material
 {
 	char* name;
@@ -485,6 +490,7 @@ typedef struct cgltf_material
 	cgltf_bool has_ior;
 	cgltf_bool has_specular;
 	cgltf_bool has_sheen;
+	cgltf_bool has_emissive_strength;
 	cgltf_pbr_metallic_roughness pbr_metallic_roughness;
 	cgltf_pbr_specular_glossiness pbr_specular_glossiness;
 	cgltf_clearcoat clearcoat;
@@ -493,6 +499,7 @@ typedef struct cgltf_material
 	cgltf_sheen sheen;
 	cgltf_transmission transmission;
 	cgltf_volume volume;
+	cgltf_emissive_strength emissive_strength;
 	cgltf_texture_view normal_texture;
 	cgltf_texture_view occlusion_texture;
 	cgltf_texture_view emissive_texture;
@@ -3844,14 +3851,14 @@ static int cgltf_parse_json_sheen(cgltf_options* options, jsmntok_t const* token
 	return i;
 }
 
-static int cgltf_parse_json_emissive_strength(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_float* out_emissive_strength)
+static int cgltf_parse_json_emissive_strength(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_emissive_strength* out_emissive_strength)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 	int size = tokens[i].size;
 	++i;
 
 	// Default
-	*out_emissive_strength = 1.f;
+	out_emissive_strength->emissive_strength = 1.f;
 
 	for (int j = 0; j < size; ++j)
 	{
@@ -3860,7 +3867,7 @@ static int cgltf_parse_json_emissive_strength(jsmntok_t const* tokens, int i, co
 		if (cgltf_json_strcmp(tokens + i, json_chunk, "emissiveStrength") == 0)
 		{
 			++i;
-			*out_emissive_strength = cgltf_json_to_float(tokens + i, json_chunk);
+			out_emissive_strength->emissive_strength = cgltf_json_to_float(tokens + i, json_chunk);
 			++i;
 		}
 		else
@@ -4253,11 +4260,8 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				}
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "KHR_materials_emissive_strength") == 0)
 				{
-					cgltf_float emissive_strength = 1.f;
-					i = cgltf_parse_json_emissive_strength(tokens, i + 1, json_chunk, &emissive_strength);
-					out_material->emissive_factor[0] *= emissive_strength;
-					out_material->emissive_factor[1] *= emissive_strength;
-					out_material->emissive_factor[2] *= emissive_strength;
+					out_material->has_emissive_strength = 1;
+					i = cgltf_parse_json_emissive_strength(tokens, i + 1, json_chunk, &out_material->emissive_strength);
 				}
 				else
 				{

--- a/cgltf.h
+++ b/cgltf.h
@@ -3844,6 +3844,39 @@ static int cgltf_parse_json_sheen(cgltf_options* options, jsmntok_t const* token
 	return i;
 }
 
+static int cgltf_parse_json_emissive_strength(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_float* out_emissive_strength)
+{
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	int size = tokens[i].size;
+	++i;
+
+	// Default
+	*out_emissive_strength = 1.f;
+
+	for (int j = 0; j < size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		if (cgltf_json_strcmp(tokens + i, json_chunk, "emissiveStrength") == 0)
+		{
+			++i;
+			*out_emissive_strength = cgltf_json_to_float(tokens + i, json_chunk);
+			++i;
+		}
+		else
+		{
+			i = cgltf_skip_json(tokens, i + 1);
+		}
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+
+	return i;
+}
+
 static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_image* out_image)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -4217,6 +4250,14 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				{
 					out_material->has_sheen = 1;
 					i = cgltf_parse_json_sheen(options, tokens, i + 1, json_chunk, &out_material->sheen);
+				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "KHR_materials_emissive_strength") == 0)
+				{
+					cgltf_float emissive_strength = 1.f;
+					i = cgltf_parse_json_emissive_strength(tokens, i + 1, json_chunk, &emissive_strength);
+					out_material->emissive_factor[0] *= emissive_strength;
+					out_material->emissive_factor[1] *= emissive_strength;
+					out_material->emissive_factor[2] *= emissive_strength;
 				}
 				else
 				{

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -84,6 +84,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #define CGLTF_EXTENSION_FLAG_MATERIALS_VARIANTS     (1 << 10)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_VOLUME       (1 << 11)
 #define CGLTF_EXTENSION_FLAG_TEXTURE_BASISU        (1 << 12)
+#define CGLTF_EXTENSION_FLAG_MATERIALS_EMISSIVE_STRENGTH (1 << 13)
 
 typedef struct {
 	char* buffer;
@@ -587,6 +588,11 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_SHEEN;
 	}
 
+	if (material->has_emissive_strength)
+	{
+		context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_EMISSIVE_STRENGTH;
+	}
+
 	if (material->has_pbr_metallic_roughness)
 	{
 		const cgltf_pbr_metallic_roughness* params = &material->pbr_metallic_roughness;
@@ -603,7 +609,7 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		cgltf_write_line(context, "}");
 	}
 
-	if (material->unlit || material->has_pbr_specular_glossiness || material->has_clearcoat || material->has_ior || material->has_specular || material->has_transmission || material->has_sheen || material->has_volume)
+	if (material->unlit || material->has_pbr_specular_glossiness || material->has_clearcoat || material->has_ior || material->has_specular || material->has_transmission || material->has_sheen || material->has_volume || material->has_emissive_strength)
 	{
 		cgltf_write_line(context, "\"extensions\": {");
 		if (material->has_clearcoat)
@@ -694,6 +700,13 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		if (material->unlit)
 		{
 			cgltf_write_line(context, "\"KHR_materials_unlit\": {}");
+		}
+		if (material->has_emissive_strength)
+		{
+			cgltf_write_line(context, "\"KHR_materials_emissive_strength\": {");
+			const cgltf_emissive_strength* params = &material->emissive_strength;
+			cgltf_write_floatprop(context, "emissiveStrength", params->emissive_strength, 1.f);
+			cgltf_write_line(context, "}");
 		}
 		cgltf_write_line(context, "}");
 	}
@@ -1096,6 +1109,9 @@ static void cgltf_write_extensions(cgltf_write_context* context, uint32_t extens
 	}
 	if (extension_flags & CGLTF_EXTENSION_FLAG_TEXTURE_BASISU) {
 		cgltf_write_stritem(context, "KHR_texture_basisu");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_EMISSIVE_STRENGTH) {
+		cgltf_write_stritem(context, "KHR_materials_emissive_strength");
 	}
 }
 


### PR DESCRIPTION
[KHR_materials_emissive_strength](https://github.com/KhronosGroup/glTF/blob/931632a785ac377f854213e764ed618c6a1b4f7f/extensions/2.0/Khronos/KHR_materials_emissive_strength/README.md) is a new extension that recently entered the "Release Candidate" status. This one is pretty simple in that the core specification limits the emissiveFactor to values in the range of [0.0 - 1.0]. This extension provides an additional multiplier to amplify emission beyond 1.0.

After discussion (below) this implementation defines a new flag, `has_emissive_strength` and an `emissive_strength` struct that embodies this float property.  The original approach is quoted here to preserve the history of this PR conversation, but no longer applies ... 

> Rather than following the route of other extensions with a `has_emissive_strength` flag and an `emissive_strength` struct, I figured it would be easier on the implementers if cgltf took the liberty of factoring in the `emissiveStrength` into the `emissiveFactor` internally. My thought is that someday we could see this extension pulled into a future version of glTF, but rather than having two "dials" to control the emissionFactor, the spec editors would instead just relax the schema constraints and allow for emission values to go beyond 1.0.

For confirmation, I locally updated Filament with these changes. Here is an altered DamagedHelmet, with the addition of the KHR_materials_emissive_strength extension that defines a strength of 5.0.

![image](https://user-images.githubusercontent.com/3868547/143138529-2ee71dd8-01bb-45a2-a15f-e5166810461e.png)

And here is the original DamagedHelmet model (i.e., emissiveFactor=[1.0, 1.0, 1.0])
![image](https://user-images.githubusercontent.com/3868547/143138839-627baddc-3fce-439e-88a6-a741c796524c.png)

TODO
 - [x] Update cgltf_write.h to write this extension if emissiveFactor is greater than 1.0.
 - [x] Update Readme

/CC @emackey @prideout
