### PR TITLE
Added *_max_enum suffixes to enumerated types and custom attributes handling

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -109,6 +109,7 @@ typedef enum cgltf_file_type
 	cgltf_file_type_invalid,
 	cgltf_file_type_gltf,
 	cgltf_file_type_glb,
+	cgltf_file_type_max_enum
 } cgltf_file_type;
 
 typedef enum cgltf_result
@@ -123,6 +124,7 @@ typedef enum cgltf_result
 	cgltf_result_io_error,
 	cgltf_result_out_of_memory,
 	cgltf_result_legacy_gltf,
+    cgltf_result_max_enum
 } cgltf_result;
 
 typedef struct cgltf_memory_options
@@ -152,6 +154,7 @@ typedef enum cgltf_buffer_view_type
 	cgltf_buffer_view_type_invalid,
 	cgltf_buffer_view_type_indices,
 	cgltf_buffer_view_type_vertices,
+	cgltf_buffer_view_type_max_enum
 } cgltf_buffer_view_type;
 
 typedef enum cgltf_attribute_type
@@ -164,6 +167,7 @@ typedef enum cgltf_attribute_type
 	cgltf_attribute_type_color,
 	cgltf_attribute_type_joints,
 	cgltf_attribute_type_weights,
+	cgltf_attribute_type_max_enum
 } cgltf_attribute_type;
 
 typedef enum cgltf_component_type
@@ -175,6 +179,7 @@ typedef enum cgltf_component_type
 	cgltf_component_type_r_16u, /* UNSIGNED_SHORT */
 	cgltf_component_type_r_32u, /* UNSIGNED_INT */
 	cgltf_component_type_r_32f, /* FLOAT */
+    cgltf_component_type_max_enum
 } cgltf_component_type;
 
 typedef enum cgltf_type
@@ -187,6 +192,7 @@ typedef enum cgltf_type
 	cgltf_type_mat2,
 	cgltf_type_mat3,
 	cgltf_type_mat4,
+	cgltf_type_max_enum
 } cgltf_type;
 
 typedef enum cgltf_primitive_type
@@ -198,6 +204,7 @@ typedef enum cgltf_primitive_type
 	cgltf_primitive_type_triangles,
 	cgltf_primitive_type_triangle_strip,
 	cgltf_primitive_type_triangle_fan,
+	cgltf_primitive_type_max_enum
 } cgltf_primitive_type;
 
 typedef enum cgltf_alpha_mode
@@ -205,6 +212,7 @@ typedef enum cgltf_alpha_mode
 	cgltf_alpha_mode_opaque,
 	cgltf_alpha_mode_mask,
 	cgltf_alpha_mode_blend,
+	cgltf_alpha_mode_max_enum
 } cgltf_alpha_mode;
 
 typedef enum cgltf_animation_path_type {
@@ -213,18 +221,21 @@ typedef enum cgltf_animation_path_type {
 	cgltf_animation_path_type_rotation,
 	cgltf_animation_path_type_scale,
 	cgltf_animation_path_type_weights,
+	cgltf_animation_path_type_max_enum
 } cgltf_animation_path_type;
 
 typedef enum cgltf_interpolation_type {
 	cgltf_interpolation_type_linear,
 	cgltf_interpolation_type_step,
 	cgltf_interpolation_type_cubic_spline,
+	cgltf_interpolation_type_max_enum
 } cgltf_interpolation_type;
 
 typedef enum cgltf_camera_type {
 	cgltf_camera_type_invalid,
 	cgltf_camera_type_perspective,
 	cgltf_camera_type_orthographic,
+	cgltf_camera_type_max_enum
 } cgltf_camera_type;
 
 typedef enum cgltf_light_type {
@@ -232,12 +243,14 @@ typedef enum cgltf_light_type {
 	cgltf_light_type_directional,
 	cgltf_light_type_point,
 	cgltf_light_type_spot,
+	cgltf_light_type_max_enum
 } cgltf_light_type;
 
 typedef enum cgltf_data_free_method {
 	cgltf_data_free_method_none,
 	cgltf_data_free_method_file_release,
 	cgltf_data_free_method_memory_free,
+	cgltf_data_free_method_max_enum
 } cgltf_data_free_method;
 
 typedef struct cgltf_extras {
@@ -267,6 +280,7 @@ typedef enum cgltf_meshopt_compression_mode {
 	cgltf_meshopt_compression_mode_attributes,
 	cgltf_meshopt_compression_mode_triangles,
 	cgltf_meshopt_compression_mode_indices,
+	cgltf_meshopt_compression_mode_max_enum
 } cgltf_meshopt_compression_mode;
 
 typedef enum cgltf_meshopt_compression_filter {
@@ -274,6 +288,7 @@ typedef enum cgltf_meshopt_compression_filter {
 	cgltf_meshopt_compression_filter_octahedral,
 	cgltf_meshopt_compression_filter_quaternion,
 	cgltf_meshopt_compression_filter_exponential,
+	cgltf_meshopt_compression_filter_max_enum
 } cgltf_meshopt_compression_filter;
 
 typedef struct cgltf_meshopt_compression

--- a/cgltf.h
+++ b/cgltf.h
@@ -1625,8 +1625,6 @@ cgltf_result cgltf_validate(cgltf_data* data)
 				for (cgltf_size k = 0; k < data->meshes[i].primitives[j].attributes_count; ++k)
 				{
 					CGLTF_ASSERT_IF(data->meshes[i].primitives[j].attributes[k].data->count != first->count, cgltf_result_invalid_gltf);
-					// note: in 3.7.2.1 of the spec it says that custom vertex attributes must not use unsigned int type
-					CGLTF_ASSERT_IF(data->meshes[i].primitives[j].attributes[k].data->component_type == cgltf_component_type_r_32u && data->meshes[i].primitives[j].attributes[k].type == cgltf_attribute_type_custom, cgltf_result_invalid_gltf);
 				}
 
 				for (cgltf_size k = 0; k < data->meshes[i].primitives[j].targets_count; ++k)

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -799,7 +799,7 @@ static const char* cgltf_write_str_path_type(cgltf_animation_path_type path_type
 		return "scale";
 	case cgltf_animation_path_type_weights:
 		return "weights";
-	case cgltf_animation_path_type_invalid:
+	default:
 		break;
 	}
 	return "invalid";
@@ -815,6 +815,8 @@ static const char* cgltf_write_str_interpolation_type(cgltf_interpolation_type i
 		return "STEP";
 	case cgltf_interpolation_type_cubic_spline:
 		return "CUBICSPLINE";
+	default:
+		break;
 	}
 	return "invalid";
 }


### PR DESCRIPTION
No comma after *_max_enum since one is not supposed to add anything after it. Test suite runs through without errors. Hope I did not miss anything.
Custom attributes have names starting with an underscore, no semantic index parsing for these (applications will probably have their own way to deal with them).