### PR TITLE
Fix documentation of cgltf_num_components()

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -63,7 +63,7 @@
  * By passing null for the output pointer, users can find out how many floats are required in the
  * output buffer.
  *
- * `cgltf_accessor_num_components` is a tiny utility that tells you the dimensionality of
+ * `cgltf_num_components` is a tiny utility that tells you the dimensionality of
  * a certain accessor type. This can be used before `cgltf_accessor_unpack_floats` to help allocate
  * the necessary amount of memory.
  *


### PR DESCRIPTION
There is no cgltf_accessor_num_components() and I guess it's too late to rename it.