### PR TITLE
Ensure that camera has a single consistent type in the file

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -4954,19 +4954,6 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 		{
 			i = cgltf_parse_json_string(options, tokens, i + 1, json_chunk, &out_camera->name);
 		}
-		else if (cgltf_json_strcmp(tokens+i, json_chunk, "type") == 0)
-		{
-			++i;
-			if (cgltf_json_strcmp(tokens + i, json_chunk, "perspective") == 0)
-			{
-				out_camera->type = cgltf_camera_type_perspective;
-			}
-			else if (cgltf_json_strcmp(tokens + i, json_chunk, "orthographic") == 0)
-			{
-				out_camera->type = cgltf_camera_type_orthographic;
-			}
-			++i;
-		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "perspective") == 0)
 		{
 			++i;
@@ -4975,6 +4962,11 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 
 			int data_size = tokens[i].size;
 			++i;
+
+			if (out_camera->type != cgltf_camera_type_invalid)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			out_camera->type = cgltf_camera_type_perspective;
 
@@ -5031,6 +5023,11 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 
 			int data_size = tokens[i].size;
 			++i;
+
+			if (out_camera->type != cgltf_camera_type_invalid)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			out_camera->type = cgltf_camera_type_orthographic;
 


### PR DESCRIPTION
With this change, we now disregard the 'type' field when parsing the camera type, and instead solely rely on the orthographic/perspective keys, and also enforce a single consistent section type during the process.

This ensures that cgltf_camera::data has been filled just once with data that came from a single JSON blob; without this it's possible to fill one struct and then fill another struct which may overwrite some union fields with invalid data, which is a significant issue for extras which contains offsets into the JSON blob.

The reason why we don't need to parse 'type' at all is that the specification says that when type is perspective or orthographic, files without a corresponding JSON section are invalid.

Note that we aren't as strict as we could possibly be, since we don't validate that the "type" field is consistent with the actual JSON structure as it doesn't affect the parsing flow.