### PR TITLE
store accessor_index for struct cgltf_primitive (indices)

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -566,6 +566,7 @@ typedef struct cgltf_mesh_gpu_instancing {
 
 typedef struct cgltf_primitive {
 	cgltf_primitive_type type;
+	cgltf_int accessor_index;
 	cgltf_accessor* indices;
 	cgltf_material* material;
 	cgltf_attribute* attributes;
@@ -3061,7 +3062,8 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "indices") == 0)
 		{
 			++i;
-			out_prim->indices = CGLTF_PTRINDEX(cgltf_accessor, cgltf_json_to_int(tokens + i, json_chunk));
+			out_prim->accessor_index = cgltf_json_to_int(tokens + i, json_chunk);
+			out_prim->indices = CGLTF_PTRINDEX(cgltf_accessor, out_prim->accessor_index);
 			++i;
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "material") == 0)


### PR DESCRIPTION
This information is valuable when attempting
to quickly access an element in the accessor
array. Makes it easier to acquire the index
buffer offset/bytes contained in larger
buffer and the amount of bytes at that offset.

**EDIT**
This information is valuable when attempting
to quickly access indices data in the accessor
array. Makes it easier to acquire the accessor
index associated with the index buffer.