### PR TITLE
store image index for a given texture

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -394,6 +394,7 @@ typedef struct cgltf_sampler
 typedef struct cgltf_texture
 {
 	char* name;
+	cgltf_int source;
 	cgltf_image* image;
 	cgltf_sampler* sampler;
 	cgltf_bool has_basisu;
@@ -4272,7 +4273,8 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "source") == 0) 
 		{
 			++i;
-			out_texture->image = CGLTF_PTRINDEX(cgltf_image, cgltf_json_to_int(tokens + i, json_chunk));
+			out_texture->source = cgltf_json_to_int(tokens + i, json_chunk);
+			out_texture->image = CGLTF_PTRINDEX(cgltf_image, out_texture->source);
 			++i;
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)


### PR DESCRIPTION
Each texture in "textures" GTLF file array has a
"source" property. This property refers to the index in the "images" GLTF file array.