### PR TITLE
replace "#ifdef _WIN32" with "#ifdef _MSC_VER"

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1023,7 +1023,7 @@ static cgltf_result cgltf_default_file_read(const struct cgltf_memory_options* m
 	{
 		fseek(file, 0, SEEK_END);
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 		__int64 length = _ftelli64(file);
 #else
 		long length = ftell(file);


### PR DESCRIPTION
this shall resolve issue 220.
[https://stackoverflow.com/questions/15127522/how-to-ifdef-by-compilertype-gcc-or-vc](https://stackoverflow.com/questions/15127522/how-to-ifdef-by-compilertype-gcc-or-vc)

Fixes #220 