### PR TITLE
Use NULL instead of 0 to silence -Wzero-as-null-pointer-constant

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1167,7 +1167,7 @@ cgltf_result cgltf_parse(const cgltf_options* options, const void* data, cgltf_s
 
 	json_chunk += GlbChunkHeaderSize;
 
-	const void* bin = 0;
+	const void* bin = NULL;
 	cgltf_size bin_size = 0;
 
 	if (GlbHeaderSize + GlbChunkHeaderSize + json_length + GlbChunkHeaderSize <= size)


### PR DESCRIPTION
This is the only place in cgltf.h where 0 is used as a pointer constant.