### PR TITLE
Simplify extensions/extra handling by trimming their support

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -328,15 +328,6 @@ typedef struct cgltf_accessor_sparse
 	cgltf_component_type indices_component_type;
 	cgltf_buffer_view* values_buffer_view;
 	cgltf_size values_byte_offset;
-	cgltf_extras extras;
-	cgltf_extras indices_extras;
-	cgltf_extras values_extras;
-	cgltf_size extensions_count;
-	cgltf_extension* extensions;
-	cgltf_size indices_extensions_count;
-	cgltf_extension* indices_extensions;
-	cgltf_size values_extensions_count;
-	cgltf_extension* values_extensions;
 } cgltf_accessor_sparse;
 
 typedef struct cgltf_accessor
@@ -419,9 +410,6 @@ typedef struct cgltf_texture_view
 	cgltf_float scale; /* equivalent to strength for occlusion_texture */
 	cgltf_bool has_transform;
 	cgltf_texture_transform transform;
-	cgltf_extras extras;
-	cgltf_size extensions_count;
-	cgltf_extension* extensions;
 } cgltf_texture_view;
 
 typedef struct cgltf_pbr_metallic_roughness
@@ -1786,12 +1774,6 @@ static void cgltf_free_extensions(cgltf_data* data, cgltf_extension* extensions,
 	data->memory.free_func(data->memory.user_data, extensions);
 }
 
-static void cgltf_free_texture_view(cgltf_data* data, cgltf_texture_view* view)
-{
-	cgltf_free_extensions(data, view->extensions, view->extensions_count);
-	cgltf_free_extras(data, &view->extras);
-}
-
 void cgltf_free(cgltf_data* data)
 {
 	if (!data)
@@ -1813,15 +1795,6 @@ void cgltf_free(cgltf_data* data)
 	{
 		data->memory.free_func(data->memory.user_data, data->accessors[i].name);
 
-		if(data->accessors[i].is_sparse)
-		{
-			cgltf_free_extensions(data, data->accessors[i].sparse.extensions, data->accessors[i].sparse.extensions_count);
-			cgltf_free_extensions(data, data->accessors[i].sparse.indices_extensions, data->accessors[i].sparse.indices_extensions_count);
-			cgltf_free_extensions(data, data->accessors[i].sparse.values_extensions, data->accessors[i].sparse.values_extensions_count);
-			cgltf_free_extras(data, &data->accessors[i].sparse.extras);
-			cgltf_free_extras(data, &data->accessors[i].sparse.indices_extras);
-			cgltf_free_extras(data, &data->accessors[i].sparse.values_extras);
-		}
 		cgltf_free_extensions(data, data->accessors[i].extensions, data->accessors[i].extensions_count);
 		cgltf_free_extras(data, &data->accessors[i].extras);
 	}
@@ -1922,54 +1895,6 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->materials_count; ++i)
 	{
 		data->memory.free_func(data->memory.user_data, data->materials[i].name);
-
-		if(data->materials[i].has_pbr_metallic_roughness)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].pbr_metallic_roughness.metallic_roughness_texture);
-			cgltf_free_texture_view(data, &data->materials[i].pbr_metallic_roughness.base_color_texture);
-		}
-		if(data->materials[i].has_pbr_specular_glossiness)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].pbr_specular_glossiness.diffuse_texture);
-			cgltf_free_texture_view(data, &data->materials[i].pbr_specular_glossiness.specular_glossiness_texture);
-		}
-		if(data->materials[i].has_clearcoat)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].clearcoat.clearcoat_texture);
-			cgltf_free_texture_view(data, &data->materials[i].clearcoat.clearcoat_roughness_texture);
-			cgltf_free_texture_view(data, &data->materials[i].clearcoat.clearcoat_normal_texture);
-		}
-		if(data->materials[i].has_specular)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].specular.specular_texture);
-			cgltf_free_texture_view(data, &data->materials[i].specular.specular_color_texture);
-		}
-		if(data->materials[i].has_transmission)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].transmission.transmission_texture);
-		}
-		if (data->materials[i].has_volume)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].volume.thickness_texture);
-		}
-		if(data->materials[i].has_sheen)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].sheen.sheen_color_texture);
-			cgltf_free_texture_view(data, &data->materials[i].sheen.sheen_roughness_texture);
-		}
-		if(data->materials[i].has_iridescence)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].iridescence.iridescence_texture);
-			cgltf_free_texture_view(data, &data->materials[i].iridescence.iridescence_thickness_texture);
-		}
-		if (data->materials[i].has_anisotropy)
-		{
-			cgltf_free_texture_view(data, &data->materials[i].anisotropy.anisotropy_texture);
-		}
-
-		cgltf_free_texture_view(data, &data->materials[i].normal_texture);
-		cgltf_free_texture_view(data, &data->materials[i].occlusion_texture);
-		cgltf_free_texture_view(data, &data->materials[i].emissive_texture);
 
 		cgltf_free_extensions(data, data->materials[i].extensions, data->materials[i].extensions_count);
 		cgltf_free_extras(data, &data->materials[i].extras);
@@ -3475,7 +3400,7 @@ static cgltf_component_type cgltf_json_to_component_type(jsmntok_t const* tok, c
 	}
 }
 
-static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor_sparse* out_sparse)
+static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor_sparse* out_sparse)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -3522,14 +3447,6 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					out_sparse->indices_component_type = cgltf_json_to_component_type(tokens + i, json_chunk);
 					++i;
 				}
-				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
-				{
-					i = cgltf_parse_json_extras(options, tokens, i + 1, json_chunk, &out_sparse->indices_extras);
-				}
-				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
-				{
-					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->indices_extensions_count, &out_sparse->indices_extensions);
-				}
 				else
 				{
 					i = cgltf_skip_json(tokens, i+1);
@@ -3565,14 +3482,6 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					out_sparse->values_byte_offset = cgltf_json_to_size(tokens + i, json_chunk);
 					++i;
 				}
-				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
-				{
-					i = cgltf_parse_json_extras(options, tokens, i + 1, json_chunk, &out_sparse->values_extras);
-				}
-				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
-				{
-					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->values_extensions_count, &out_sparse->values_extensions);
-				}
 				else
 				{
 					i = cgltf_skip_json(tokens, i+1);
@@ -3583,14 +3492,6 @@ static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t co
 					return i;
 				}
 			}
-		}
-		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
-		{
-			i = cgltf_parse_json_extras(options, tokens, i + 1, json_chunk, &out_sparse->extras);
-		}
-		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
-		{
-			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->extensions_count, &out_sparse->extensions);
 		}
 		else
 		{
@@ -3705,7 +3606,7 @@ static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* to
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "sparse") == 0)
 		{
 			out_accessor->is_sparse = 1;
-			i = cgltf_parse_json_accessor_sparse(options, tokens, i + 1, json_chunk, &out_accessor->sparse);
+			i = cgltf_parse_json_accessor_sparse(tokens, i + 1, json_chunk, &out_accessor->sparse);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
@@ -3777,6 +3678,8 @@ static int cgltf_parse_json_texture_transform(jsmntok_t const* tokens, int i, co
 
 static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_texture_view* out_texture_view)
 {
+	(void)options;
+
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
 	out_texture_view->scale = 1.0f;
@@ -3813,28 +3716,12 @@ static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const
 			out_texture_view->scale = cgltf_json_to_float(tokens + i, json_chunk);
 			++i;
 		}
-		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
-		{
-			i = cgltf_parse_json_extras(options, tokens, i + 1, json_chunk, &out_texture_view->extras);
-		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
 		{
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-			if(out_texture_view->extensions)
-			{
-				return CGLTF_ERROR_JSON;
-			}
-
 			int extensions_size = tokens[i].size;
-			out_texture_view->extensions_count = 0;
-			out_texture_view->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
-
-			if (!out_texture_view->extensions)
-			{
-				return CGLTF_ERROR_NOMEM;
-			}
 
 			++i;
 
@@ -3849,7 +3736,7 @@ static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const
 				}
 				else
 				{
-					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture_view->extensions[out_texture_view->extensions_count++]));
+					i = cgltf_skip_json(tokens, i + 1);
 				}
 
 				if (i < 0)
@@ -3903,13 +3790,11 @@ static int cgltf_parse_json_pbr_metallic_roughness(cgltf_options* options, jsmnt
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "baseColorTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
-				&out_pbr->base_color_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_pbr->base_color_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "metallicRoughnessTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
-				&out_pbr->metallic_roughness_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_pbr->metallic_roughness_texture);
 		}
 		else
 		{

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -153,7 +153,6 @@ typedef struct {
 			context->extension_flags |= CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM; \
 			cgltf_write_texture_transform(context, &info.transform); \
 		} \
-		cgltf_write_extras(context, &info.extras); \
 		cgltf_write_line(context, "}"); }
 
 #define CGLTF_WRITE_NORMAL_TEXTURE_INFO(label, info) if (info.texture) { \
@@ -165,7 +164,6 @@ typedef struct {
 			context->extension_flags |= CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM; \
 			cgltf_write_texture_transform(context, &info.transform); \
 		} \
-		cgltf_write_extras(context, &info.extras); \
 		cgltf_write_line(context, "}"); }
 
 #define CGLTF_WRITE_OCCLUSION_TEXTURE_INFO(label, info) if (info.texture) { \
@@ -177,7 +175,6 @@ typedef struct {
 			context->extension_flags |= CGLTF_EXTENSION_FLAG_TEXTURE_TRANSFORM; \
 			cgltf_write_texture_transform(context, &info.transform); \
 		} \
-		cgltf_write_extras(context, &info.extras); \
 		cgltf_write_line(context, "}"); }
 
 #ifndef CGLTF_CONSTS
@@ -1058,14 +1055,11 @@ static void cgltf_write_accessor(cgltf_write_context* context, const cgltf_acces
 		cgltf_write_sizeprop(context, "byteOffset", (int)accessor->sparse.indices_byte_offset, 0);
 		CGLTF_WRITE_IDXPROP("bufferView", accessor->sparse.indices_buffer_view, context->data->buffer_views);
 		cgltf_write_intprop(context, "componentType", cgltf_int_from_component_type(accessor->sparse.indices_component_type), 0);
-		cgltf_write_extras(context, &accessor->sparse.indices_extras);
 		cgltf_write_line(context, "}");
 		cgltf_write_line(context, "\"values\": {");
 		cgltf_write_sizeprop(context, "byteOffset", (int)accessor->sparse.values_byte_offset, 0);
 		CGLTF_WRITE_IDXPROP("bufferView", accessor->sparse.values_buffer_view, context->data->buffer_views);
-		cgltf_write_extras(context, &accessor->sparse.values_extras);
 		cgltf_write_line(context, "}");
-		cgltf_write_extras(context, &accessor->sparse.extras);
 		cgltf_write_line(context, "}");
 	}
 	cgltf_write_extras(context, &accessor->extras);


### PR DESCRIPTION
This change removes support for extras and extensions from cgltf_accessor_sparse and cgltf_texture_view to simplify memory management.

The motivation for this change is that both accessor_sparse and texture_view are deeply nested in glTF structures and simultaneously rarely extended; there are no known extensions for internals of sparse accessors, and only one (KHR_texture_transform) extension for texture views which is supported by cgltf natively.

The presence of these inflates the cgltf data structures; while it would be reasonable to do given specific use cases, we do not have specific use cases here.

Additionally, for cgltf_texture_view, this type is heavily used by the materials which is a very active area of development in glTF ecosystem. Many newer extensions are added gradually that introduce more texture view objects, and with each extension there is a risk that cgltf_free_texture_view et al will be forgotten - indeed, this happened several times for newly introduced extensions.

Finally, for cgltf_texture_view, due to the current code structure, the presence of KHR_texture_transform extension causes us to allocate arrays of unprocessed extensions, only to never use them later. While this is a general problem that could manifest in other places, this specific place is something where this can happen often when the assets are using quantized texture coordinates, and can be easily avoided because we don't actually need to support extensions.

Note that cgltf_write didn't even support extensions in either of these cases in the first place.

Fixes #118.
Tested with 4B of fuzzing iterations in addition to gltfpack.