### PR TITLE
Remove float->int casts from read_integer/read_index

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2225,8 +2225,6 @@ static cgltf_ssize cgltf_component_read_integer(const void* in, cgltf_component_
 			return *((const uint16_t*) in);
 		case cgltf_component_type_r_32u:
 			return *((const uint32_t*) in);
-		case cgltf_component_type_r_32f:
-			return (cgltf_ssize)*((const float*) in);
 		case cgltf_component_type_r_8:
 			return *((const int8_t*) in);
 		case cgltf_component_type_r_8u:
@@ -2244,8 +2242,6 @@ static cgltf_size cgltf_component_read_index(const void* in, cgltf_component_typ
 			return *((const uint16_t*) in);
 		case cgltf_component_type_r_32u:
 			return *((const uint32_t*) in);
-		case cgltf_component_type_r_32f:
-			return (cgltf_size)((cgltf_ssize)*((const float*) in));
 		case cgltf_component_type_r_8u:
 			return *((const uint8_t*) in);
 		default:


### PR DESCRIPTION
The float->int cast in read_integer is unreachable as this function is only called from read_float, and it handles r_32f separately.

The float->int cast in read_index is reachable since the caller may call accessor_read_index or unpack_indices on a floating-point buffer. However, there should be no valid circumstances to do this as cases when glTF buffers carry index data (geometry indices, sparse accessors) require unnormalized integers by the spec. This is also underscored by read_index only handling unsigned integer types.

Based on the discussion in #227 the support for float->int cast is somewhat accidental and is unlikely to be required by existing users.