### PR TITLE
Validate that material variant names aren't NULL

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1740,6 +1740,11 @@ cgltf_result cgltf_validate(cgltf_data* data)
 		}
 	}
 
+	for (cgltf_size i = 0; i < data->variants_count; ++i)
+	{
+		CGLTF_ASSERT_IF(!data->variants[i].name, cgltf_result_invalid_gltf);
+	}
+
 	return cgltf_result_success;
 }
 


### PR DESCRIPTION
Some names in glTF data structures are required and some are optional.

We normally ensure that names that are required can't be NULL as a byproduct of how they are parsed: required names usually come up when they are JSON object keys, so a lack of a name means the object isn't parsed.

Material variants are an odd exception: the name is required (in fact it's the only thing that a variant has...), but it's stored as a "name" key in an array of objects because the extension needs to maintain variant order. It's natural for the user to assume that the name is not NULL as the spec requires that, but it can be NULL in non-compliant documents, so we validate this now.