### PR TITLE
Ensure that for builtin types, attribute index is non-negative

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2810,6 +2810,11 @@ static void cgltf_parse_attribute_type(const char* name, cgltf_attribute_type* o
 	if (us && *out_type != cgltf_attribute_type_invalid)
 	{
 		*out_index = CGLTF_ATOI(us + 1);
+		if (*out_index < 0)
+		{
+			*out_type = cgltf_attribute_type_invalid;
+			*out_index = 0;
+		}
 	}
 }
 


### PR DESCRIPTION
glTF specification guarantees that the indices of builtin attributes are natural numbers; atoi can return a negative number, which is likely to cause problems for client code (for example, even if it attempts to range-check the texture coordinate index before writing it to internal mesh representation, index < 8 will not work because index can be negative).