### PR TITLE
Remove VLA usage for GLB size constants

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -938,8 +938,8 @@ static int jsmn_parse(jsmn_parser *parser, const char *js, size_t len, jsmntok_t
 
 
 #ifndef CGLTF_CONSTS
-static const cgltf_size GlbHeaderSize = 12;
-static const cgltf_size GlbChunkHeaderSize = 8;
+#define GlbHeaderSize 12
+#define GlbChunkHeaderSize 8
 static const uint32_t GlbVersion = 2;
 static const uint32_t GlbMagic = 0x46546C67;
 static const uint32_t GlbMagicJsonChunk = 0x4E4F534A;

--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -178,8 +178,8 @@ typedef struct {
 		cgltf_write_line(context, "}"); }
 
 #ifndef CGLTF_CONSTS
-static const cgltf_size GlbHeaderSize = 12;
-static const cgltf_size GlbChunkHeaderSize = 8;
+#define GlbHeaderSize 12
+#define GlbChunkHeaderSize 8
 static const uint32_t GlbVersion = 2;
 static const uint32_t GlbMagic = 0x46546C67;
 static const uint32_t GlbMagicJsonChunk = 0x4E4F534A;


### PR DESCRIPTION
Opinions on whether VLA's are a good feature tend to be pretty mixed. Regardless of opinion, Microsoft's MSVC compiler does not support them, and any project attempting to use the C89 standard won't either.

The VLA's in this library aren't even of variable size - their sizes are known at compile time.


Love the library, thanks for building & supporting it!