### PR TITLE
Fix integer overflow during GLB chunk length validation

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1147,7 +1147,7 @@ cgltf_result cgltf_parse(const cgltf_options* options, const void* data, cgltf_s
 	// JSON chunk: length
 	uint32_t json_length;
 	memcpy(&json_length, json_chunk, 4);
-	if (GlbHeaderSize + GlbChunkHeaderSize + json_length > size)
+	if (json_length > size - GlbHeaderSize - GlbChunkHeaderSize)
 	{
 		return cgltf_result_data_too_short;
 	}
@@ -1164,7 +1164,7 @@ cgltf_result cgltf_parse(const cgltf_options* options, const void* data, cgltf_s
 	const void* bin = NULL;
 	cgltf_size bin_size = 0;
 
-	if (GlbHeaderSize + GlbChunkHeaderSize + json_length + GlbChunkHeaderSize <= size)
+	if (GlbChunkHeaderSize <= size - GlbHeaderSize - GlbChunkHeaderSize - json_length)
 	{
 		// We can read another chunk
 		const uint8_t* bin_chunk = json_chunk + json_length;
@@ -1172,7 +1172,7 @@ cgltf_result cgltf_parse(const cgltf_options* options, const void* data, cgltf_s
 		// Bin chunk: length
 		uint32_t bin_length;
 		memcpy(&bin_length, bin_chunk, 4);
-		if (GlbHeaderSize + GlbChunkHeaderSize + json_length + GlbChunkHeaderSize + bin_length > size)
+		if (bin_length > size - GlbHeaderSize - GlbChunkHeaderSize - json_length - GlbChunkHeaderSize)
 		{
 			return cgltf_result_data_too_short;
 		}


### PR DESCRIPTION
Validation of input lengths must be performed by comparing the length with the remainder of the input data; the latter can be safely computed because we validate the remainder after every step incrementally.

Before this change, length validation was doing math in 32-bit space and could thus overflow, exposing data after the input buffer to the parser.

This was always a problem on 32-bit systems; it only became a problem on 64-bit systems after the VLA change, as before it GlbHeaderSize et al had type cgltf_size.

Found by fuzzing. Regression (on 64-bit systems) since #238.