### PR TITLE
Change error code on sampler count mismatch to invalid_gltf

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -1738,7 +1738,7 @@ cgltf_result cgltf_validate(cgltf_data* data)
 
 			cgltf_size values = channel->sampler->interpolation == cgltf_interpolation_type_cubic_spline ? 3 : 1;
 
-			CGLTF_ASSERT_IF(channel->sampler->input->count * components * values != channel->sampler->output->count, cgltf_result_data_too_short);
+			CGLTF_ASSERT_IF(channel->sampler->input->count * components * values != channel->sampler->output->count, cgltf_result_invalid_gltf);
 		}
 	}
 


### PR DESCRIPTION
This error as it stands is a little misleading: it's the only case where we emit an error like this when the sizes aren't equal, so it can hit when the output count is *larger* (so there's technically enough data, but the glTF file is still invalid per spec / per Khronos validator). In other cases where a size mismatches like this we currently emit invalid_gltf so this seems to make more sense.