### PR TITLE
Change `cgltf_accessor_unpack_indices` to work with int vectors

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2638,7 +2638,10 @@ cgltf_size cgltf_accessor_unpack_indices(const cgltf_accessor* accessor, void* o
 		return accessor->count;
 	}
 
-	index_count = accessor->count < index_count ? accessor->count : index_count;
+	cgltf_size numbers_per_element = cgltf_num_components(accessor->type);
+	cgltf_size available_numbers = accessor->count * numbers_per_element;
+
+	index_count = available_numbers < index_count ? available_numbers : index_count;
 	cgltf_size index_component_size = cgltf_component_size(accessor->component_type);
 
 	if (accessor->is_sparse)
@@ -2660,15 +2663,23 @@ cgltf_size cgltf_accessor_unpack_indices(const cgltf_accessor* accessor, void* o
 	}
 	element += accessor->offset;
 
-	if (index_component_size == out_component_size && accessor->stride == out_component_size)
+	if (index_component_size == out_component_size && accessor->stride == out_component_size * numbers_per_element)
 	{
 		memcpy(out, element, index_count * index_component_size);
 		return index_count;
 	}
 
+	// Data couldn't be copied with memcpy due to stride being larger than the component size.
+	// OR
 	// The component size of the output array is larger than the component size of the index data, so index data will be padded.
 	switch (out_component_size)
 	{
+	case 1:
+		for (cgltf_size index = 0; index < index_count; index++, element += accessor->stride)
+		{
+			((uint8_t*)out)[index] = (uint8_t)cgltf_component_read_index(element, accessor->component_type);
+		}
+		break;
 	case 2:
 		for (cgltf_size index = 0; index < index_count; index++, element += accessor->stride)
 		{
@@ -2682,7 +2693,7 @@ cgltf_size cgltf_accessor_unpack_indices(const cgltf_accessor* accessor, void* o
 		}
 		break;
 	default:
-		break;
+		return 0;
 	}
 
 	return index_count;


### PR DESCRIPTION
This PR introduces 3 improvements to the
`cgltf_accessor_unpack_indices` function:
1. Query `cgltf_num_components` and use it to load int vectors properly - this is useful for loading vec4 uint8_t joint indices.
2. Add support for uint8_t in slow path (for loop) in cases where data wasn't tightly packed (previously the function wouldn't do anything).
3. Return 0 on failure instead of failing silently and leaving memory uninitialized.