### PR TITLE
Fix output name of anisotropyStrength

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -815,7 +815,7 @@ static void cgltf_write_material(cgltf_write_context* context, const cgltf_mater
 		{
 			cgltf_write_line(context, "\"KHR_materials_anisotropy\": {");
 			const cgltf_anisotropy* params = &material->anisotropy;
-			cgltf_write_floatprop(context, "anisotropyFactor", params->anisotropy_strength, 0.f);
+			cgltf_write_floatprop(context, "anisotropyStrength", params->anisotropy_strength, 0.f);
 			cgltf_write_floatprop(context, "anisotropyRotation", params->anisotropy_rotation, 0.f);
 			CGLTF_WRITE_TEXTURE_INFO("anisotropyTexture", params->anisotropy_texture);
 			cgltf_write_line(context, "}");


### PR DESCRIPTION
cgltf_write.h has the incorrect name for `anisotropyStrength`.

The reader has the correct name.  See:

https://github.com/jkuhlmann/cgltf/blob/08470a2b08980cd3221002a9b2ef29a37e3111dc/cgltf.h#L4389

I noticed during round-trip testing that the name was getting changed, so this is a small fix to correct it.