### PR TITLE
Add cgltf_accessor_data() helper

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2340,6 +2340,17 @@ const uint8_t* cgltf_buffer_view_data(const cgltf_buffer_view* view)
 	return result;
 }
 
+const uint8_t* cgltf_accessor_data(const cgltf_accessor* accessor)
+{
+	const uint8_t* result = cgltf_buffer_view_data(accessor->buffer_view);
+	if (result == NULL)
+	{
+		return 0;
+	}
+	result += accessor->offset;
+	return result;
+}
+
 const cgltf_accessor* cgltf_find_accessor(const cgltf_primitive* prim, cgltf_attribute_type type, cgltf_int index)
 {
 	for (cgltf_size i = 0; i < prim->attributes_count; ++i)
@@ -2398,12 +2409,12 @@ cgltf_bool cgltf_accessor_read_float(const cgltf_accessor* accessor, cgltf_size 
 		memset(out, 0, element_size * sizeof(cgltf_float));
 		return 1;
 	}
-	const uint8_t* element = cgltf_buffer_view_data(accessor->buffer_view);
+	const uint8_t* element = cgltf_accessor_data(accessor);
 	if (element == NULL)
 	{
 		return 0;
 	}
-	element += accessor->offset + accessor->stride * index;
+	element += accessor->stride * index;
 	return cgltf_element_read_float(element, accessor->type, accessor->component_type, accessor->normalized, out, element_size);
 }
 
@@ -2426,12 +2437,11 @@ cgltf_size cgltf_accessor_unpack_floats(const cgltf_accessor* accessor, cgltf_fl
 	}
 	else
 	{
-		const uint8_t* element = cgltf_buffer_view_data(accessor->buffer_view);
+		const uint8_t* element = cgltf_accessor_data(accessor);
 		if (element == NULL)
 		{
 			return 0;
 		}
-		element += accessor->offset;
 
 		if (accessor->component_type == cgltf_component_type_r_32f && accessor->stride == floats_per_element * sizeof(cgltf_float))
 		{
@@ -2544,12 +2554,12 @@ cgltf_bool cgltf_accessor_read_uint(const cgltf_accessor* accessor, cgltf_size i
 		memset(out, 0, element_size * sizeof(cgltf_uint));
 		return 1;
 	}
-	const uint8_t* element = cgltf_buffer_view_data(accessor->buffer_view);
+	const uint8_t* element = cgltf_accessor_data(accessor);
 	if (element == NULL)
 	{
 		return 0;
 	}
-	element += accessor->offset + accessor->stride * index;
+	element += accessor->stride * index;
 	return cgltf_element_read_uint(element, accessor->type, accessor->component_type, out, element_size);
 }
 
@@ -2565,12 +2575,12 @@ cgltf_size cgltf_accessor_read_index(const cgltf_accessor* accessor, cgltf_size 
 	{
 		return 0;
 	}
-	const uint8_t* element = cgltf_buffer_view_data(accessor->buffer_view);
+	const uint8_t* element = cgltf_accessor_data(accessor);
 	if (element == NULL)
 	{
 		return 0; // This is an error case, but we can't communicate the error with existing interface.
 	}
-	element += accessor->offset + accessor->stride * index;
+	element += accessor->stride * index;
 	return cgltf_component_read_index(element, accessor->component_type);
 }
 
@@ -2695,12 +2705,11 @@ cgltf_size cgltf_accessor_unpack_indices(const cgltf_accessor* accessor, void* o
 	{
 		return 0;
 	}
-	const uint8_t* element = cgltf_buffer_view_data(accessor->buffer_view);
+	const uint8_t* element = cgltf_accessor_data(accessor);
 	if (element == NULL)
 	{
 		return 0;
 	}
-	element += accessor->offset;
 
 	if (index_component_size == out_component_size && accessor->stride == out_component_size * numbers_per_element)
 	{


### PR DESCRIPTION
When fetching data from an accessor there is this common code:

```
const uint8_t* element = cgltf_buffer_view_data(accessor->buffer_view);
if (element == NULL)
{
	return 0;
}
element += accessor->offset;
```
I propose adding a helper function `cgltf_accessor_data()` to reduce this boilerplate - I actually had a hidden bug in my code because I was not checking if buffer view data was null before adding accessor offset, so I think it's worthwhile even if it adds an extra null check.

I ran `python test_all.py` with no errors.