### PR TITLE
Add file size to cgltf_file_options::release callback

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -141,7 +141,7 @@ typedef struct cgltf_memory_options
 typedef struct cgltf_file_options
 {
 	cgltf_result(*read)(const struct cgltf_memory_options* memory_options, const struct cgltf_file_options* file_options, const char* path, cgltf_size* size, void** data);
-	void (*release)(const struct cgltf_memory_options* memory_options, const struct cgltf_file_options* file_options, void* data);
+	void (*release)(const struct cgltf_memory_options* memory_options, const struct cgltf_file_options* file_options, void* data, cgltf_size size);
 	void* user_data;
 } cgltf_file_options;
 
@@ -769,6 +769,7 @@ typedef struct cgltf_data
 {
 	cgltf_file_type file_type;
 	void* file_data;
+	cgltf_size file_size;
 
 	cgltf_asset asset;
 
@@ -1099,9 +1100,10 @@ static cgltf_result cgltf_default_file_read(const struct cgltf_memory_options* m
 	return cgltf_result_success;
 }
 
-static void cgltf_default_file_release(const struct cgltf_memory_options* memory_options, const struct cgltf_file_options* file_options, void* data)
+static void cgltf_default_file_release(const struct cgltf_memory_options* memory_options, const struct cgltf_file_options* file_options, void* data, cgltf_size size)
 {
 	(void)file_options;
+	(void)size;
 	void (*memfree)(void*, void*) = memory_options->free_func ? memory_options->free_func : &cgltf_default_free;
 	memfree(memory_options->user_data, data);
 }
@@ -1248,7 +1250,7 @@ cgltf_result cgltf_parse_file(const cgltf_options* options, const char* path, cg
 	}
 
 	cgltf_result (*file_read)(const struct cgltf_memory_options*, const struct cgltf_file_options*, const char*, cgltf_size*, void**) = options->file.read ? options->file.read : &cgltf_default_file_read;
-	void (*file_release)(const struct cgltf_memory_options*, const struct cgltf_file_options*, void* data) = options->file.release ? options->file.release : cgltf_default_file_release;
+	void (*file_release)(const struct cgltf_memory_options*, const struct cgltf_file_options*, void* data, cgltf_size size) = options->file.release ? options->file.release : cgltf_default_file_release;
 
 	void* file_data = NULL;
 	cgltf_size file_size = 0;
@@ -1262,11 +1264,12 @@ cgltf_result cgltf_parse_file(const cgltf_options* options, const char* path, cg
 
 	if (result != cgltf_result_success)
 	{
-		file_release(&options->memory, &options->file, file_data);
+		file_release(&options->memory, &options->file, file_data, file_size);
 		return result;
 	}
 
 	(*out_data)->file_data = file_data;
+	(*out_data)->file_size = file_size;
 
 	return cgltf_result_success;
 }
@@ -1850,7 +1853,7 @@ void cgltf_free(cgltf_data* data)
 		return;
 	}
 
-	void (*file_release)(const struct cgltf_memory_options*, const struct cgltf_file_options*, void* data) = data->file.release ? data->file.release : cgltf_default_file_release;
+	void (*file_release)(const struct cgltf_memory_options*, const struct cgltf_file_options*, void* data, cgltf_size size) = data->file.release ? data->file.release : cgltf_default_file_release;
 
 	data->memory.free_func(data->memory.user_data, data->asset.copyright);
 	data->memory.free_func(data->memory.user_data, data->asset.generator);
@@ -1885,7 +1888,7 @@ void cgltf_free(cgltf_data* data)
 
 		if (data->buffers[i].data_free_method == cgltf_data_free_method_file_release)
 		{
-			file_release(&data->memory, &data->file, data->buffers[i].data);
+			file_release(&data->memory, &data->file, data->buffers[i].data, data->buffers[i].size);
 		}
 		else if (data->buffers[i].data_free_method == cgltf_data_free_method_memory_free)
 		{
@@ -2124,7 +2127,7 @@ void cgltf_free(cgltf_data* data)
 
 	data->memory.free_func(data->memory.user_data, data->extensions_required);
 
-	file_release(&data->memory, &data->file, data->file_data);
+	file_release(&data->memory, &data->file, data->file_data, data->file_size);
 
 	data->memory.free_func(data->memory.user_data, data);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required(VERSION 3.5...3.30)
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 


### PR DESCRIPTION
This is necessary for POSIX systems to be able to implement file loading via mmap/munmap since munmap takes the size (unlike Windows). Without this, the implementation would need to keep a map from file pointer to file size to be able to unmap the file.

This change requires minor adjustment for people who use file callbacks but the change should be very straightforward and will be flagged during the upgrade by the compiler.