### PR TITLE
Implemented KHR_gaussian_splatting extension

### DIFF
--- a/cgltf_write.h
+++ b/cgltf_write.h
@@ -89,6 +89,7 @@ cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size si
 #define CGLTF_EXTENSION_FLAG_MATERIALS_DISPERSION (1 << 17)
 #define CGLTF_EXTENSION_FLAG_TEXTURE_WEBP          (1 << 18)
 #define CGLTF_EXTENSION_FLAG_MATERIALS_DIFFUSE_TRANSMISSION (1 << 19)
+#define CGLTF_EXTENSION_FLAG_GAUSSIAN_SPLATTING     (1 << 20)
 
 typedef struct {
 	char* buffer;
@@ -499,7 +500,7 @@ static void cgltf_write_primitive(cgltf_write_context* context, const cgltf_prim
 	}
 	cgltf_write_extras(context, &prim->extras);
 
-	if (prim->has_draco_mesh_compression || prim->mappings_count > 0)
+	if (prim->has_draco_mesh_compression || prim->has_gaussian_splatting || prim->mappings_count > 0)
 	{
 		cgltf_write_line(context, "\"extensions\": {");
 
@@ -523,6 +524,18 @@ static void cgltf_write_primitive(cgltf_write_context* context, const cgltf_prim
 			cgltf_write_line(context, "}");
 		}
 
+		if (prim->has_gaussian_splatting)
+		{
+			context->extension_flags |= CGLTF_EXTENSION_FLAG_GAUSSIAN_SPLATTING;
+			cgltf_write_line(context, "\"KHR_gaussian_splatting\": {");
+			cgltf_write_strprop(context, "kernel", prim->gaussian_splatting.kernel);
+			cgltf_write_strprop(context, "colorSpace", prim->gaussian_splatting.color_space);
+			cgltf_write_strprop(context, "sortingMethod", prim->gaussian_splatting.sorting_method);
+			cgltf_write_strprop(context, "projection", prim->gaussian_splatting.projection);
+			cgltf_write_extras(context, &prim->gaussian_splatting.extras);
+			cgltf_write_line(context, "}");
+		}
+		
 		if (prim->mappings_count > 0)
 		{
 			context->extension_flags |= CGLTF_EXTENSION_FLAG_MATERIALS_VARIANTS;
@@ -1328,6 +1341,9 @@ static void cgltf_write_extensions(cgltf_write_context* context, uint32_t extens
 	}
 	if (extension_flags & CGLTF_EXTENSION_FLAG_MATERIALS_DISPERSION) {
 		cgltf_write_stritem(context, "KHR_materials_dispersion");
+	}
+	if (extension_flags & CGLTF_EXTENSION_FLAG_GAUSSIAN_SPLATTING) {
+		cgltf_write_stritem(context, "KHR_gaussian_splatting");
 	}
 }
 


### PR DESCRIPTION
This PR implements reading/writing of the [KHR_gaussian_splatting](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_gaussian_splatting) extension, which has recently entered the release candidate extension phase.

This extension allows one to indicate that a primitive is meant to be interpreted as a collection of [Gaussian splats](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/). The extension object contains a handful of properties that support the interpretation of the primitive's attributes as a Gaussian splat cloud. These properties are all of string type, since it is expected that future extensions (which have already begun to emerge) will add additional values. For this reason, these properties should not be converted to close-ended enumerations.

Most of the work to support this extension is done by the importer/renderer: extension-scoped primitive attributes store Gaussian-specific data (such as opacity, scale, and spherical harmonics coefficients for storing viewpoint-dependent colors). The extension object itself is very lightweight, consisting of metadata that affects how the Gaussians should be rendered.

This PR will remain a draft until the extension is fully ratified by Khronos. Any comments welcome in the meantime.