### PR TITLE
Change cgltf_component_read_float so it handles correctly snorm

### DIFF
--- a/cgltf.h
+++ b/cgltf.h
@@ -2261,13 +2261,15 @@ static cgltf_float cgltf_component_read_float(const void* in, cgltf_component_ty
 		{
 			// note: glTF spec doesn't currently define normalized conversions for 32-bit integers
 			case cgltf_component_type_r_16:
-				return *((const int16_t*) in) / (cgltf_float)32767;
+				int16_t x16 = *((const int16_t*)in);
+				return x16 == -32768 ? -1.0f : x16 * (1.f / (cgltf_float)32767);
 			case cgltf_component_type_r_16u:
-				return *((const uint16_t*) in) / (cgltf_float)65535;
+				return *((const uint16_t*) in) * (1.f / (cgltf_float)65535);
 			case cgltf_component_type_r_8:
-				return *((const int8_t*) in) / (cgltf_float)127;
+				int8_t x8 = *((const int8_t*)in);
+				return x8 == -128 ? -1 : *((const int8_t*) in) * (1.f / (cgltf_float)127);
 			case cgltf_component_type_r_8u:
-				return *((const uint8_t*) in) / (cgltf_float)255;
+				return *((const uint8_t*) in) / (1.f / (cgltf_float)255);
 			default:
 				return 0;
 		}

--- a/cgltf.h
+++ b/cgltf.h
@@ -2261,13 +2261,17 @@ static cgltf_float cgltf_component_read_float(const void* in, cgltf_component_ty
 		{
 			// note: glTF spec doesn't currently define normalized conversions for 32-bit integers
 			case cgltf_component_type_r_16:
+			{
 				int16_t x16 = *((const int16_t*)in);
 				return x16 == -32768 ? -1.0f : x16 * (1.f / (cgltf_float)32767);
+			}
 			case cgltf_component_type_r_16u:
 				return *((const uint16_t*) in) * (1.f / (cgltf_float)65535);
 			case cgltf_component_type_r_8:
+			{
 				int8_t x8 = *((const int8_t*)in);
 				return x8 == -128 ? -1 : *((const int8_t*) in) * (1.f / (cgltf_float)127);
+			}
 			case cgltf_component_type_r_8u:
 				return *((const uint8_t*) in) / (1.f / (cgltf_float)255);
 			default:


### PR DESCRIPTION
I have made a small change to the way `cgltf_component_read_float` converts snorm to float.

The problem was that the lowest value was not being converted to -1.0f.

For example i8 has range [-128, +127]. \
If you just divide by 127, the mapped range is [-1.007874f, -1.0f].

The solution is simply, if == -128, then return -1.

In addition to that, I have replaced the division for the equivalent multiplication for performance.

Here are a couple of links about snorm conversion: \
OpenGL: https://github.com/nlguillemot/SNormTest \
DX: https://learn.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-data-conversion \
Vulkan: https://docs.vulkan.org/spec/latest/chapters/fundamentals.html#fundamentals-fixedfpconv

I hope it's all good. \
Thanks for making this library, it's awesome!